### PR TITLE
fix: player-empire selection & extraction for Stellaris 4.x (Pegasus) saves

### DIFF
--- a/backend/core/companion.py
+++ b/backend/core/companion.py
@@ -1143,7 +1143,7 @@ class Companion:
         diplomacy = self.extractor.get_diplomacy()
 
         return {
-            "empire_name": self.metadata.get("name", "Unknown"),
+            "empire_name": player.get("empire_name") or self.metadata.get("name", "Unknown"),
             "date": self.metadata.get("date", "Unknown"),
             "military_power": player.get("military_power", 0),
             "fleet_count": player.get("fleet_count", 0),

--- a/dev.sh
+++ b/dev.sh
@@ -53,11 +53,13 @@ cleanup_orphans
 # Start Python backend in background (use venv if available)
 echo "📦 Starting Python backend on :8742..."
 if [ -f "venv/bin/python3" ]; then
-  venv/bin/python3 -m backend.electron_main &
+  PYTHON="venv/bin/python3"
+elif [ -f "venv/Scripts/python.exe" ]; then
+  PYTHON="venv/Scripts/python.exe"
 else
-  python3 -m backend.electron_main &
+  PYTHON="${PYTHON:-python3}"
 fi
-PYTHON_PID=$!
+"$PYTHON" -m backend.electron_main &
 
 # Wait for backend to be ready
 echo "⏳ Waiting for backend..."

--- a/dev.sh
+++ b/dev.sh
@@ -26,13 +26,21 @@ echo "   DB Path: $STELLARIS_DB_PATH"
 echo ""
 
 # Kill any orphaned backend processes from previous runs
-cleanup_orphans() {
-  local pids=$(lsof -ti:8742 2>/dev/null || true)
-  if [ -n "$pids" ]; then
-    echo "🧹 Cleaning up orphaned processes on port 8742..."
-    echo "$pids" | xargs kill -9 2>/dev/null || true
-    sleep 0.5
+kill_port() {
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -ti:"$1" 2>/dev/null | xargs kill -9 2>/dev/null || true
+  else
+    powershell.exe -NoProfile -Command \
+      "Get-NetTCPConnection -LocalPort $1 -State Listen -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id \$_.OwningProcess -Force }" \
+      >/dev/null 2>&1 || true
   fi
+}
+
+cleanup_orphans() {
+  echo "🧹 Cleaning up orphaned processes on ports 8742/5173..."
+  kill_port 8742
+  kill_port 5173
+  sleep 0.5
 }
 
 # Cleanup function for shutdown
@@ -59,6 +67,34 @@ elif [ -f "venv/Scripts/python.exe" ]; then
 else
   PYTHON="${PYTHON:-python3}"
 fi
+
+# Multiplayer player-empire override. In dev mode this script launches the
+# backend directly, so Electron's env injection is bypassed. Mirror it by
+# reading the override the app stored in its settings.json (unless already set
+# explicitly via .env / the environment).
+if [ -z "$STELLARIS_PLAYER_NAME" ] && [ -z "$STELLARIS_PLAYER_COUNTRY_ID" ]; then
+  SETTINGS_JSON=""
+  if [ -n "$APPDATA" ] && [ -f "$APPDATA/stellaris-companion/settings.json" ]; then
+    SETTINGS_JSON="$APPDATA/stellaris-companion/settings.json"
+  elif [ -f "$HOME/.config/stellaris-companion/settings.json" ]; then
+    SETTINGS_JSON="$HOME/.config/stellaris-companion/settings.json"
+  elif [ -f "$HOME/Library/Application Support/stellaris-companion/settings.json" ]; then
+    SETTINGS_JSON="$HOME/Library/Application Support/stellaris-companion/settings.json"
+  fi
+  if [ -n "$SETTINGS_JSON" ]; then
+    PLAYER_NAME="$("$PYTHON" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('playerName') or '')" "$SETTINGS_JSON" 2>/dev/null || true)"
+    PLAYER_CID="$("$PYTHON" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('playerCountryId') or '')" "$SETTINGS_JSON" 2>/dev/null || true)"
+    if [ -n "$PLAYER_NAME" ]; then
+      export STELLARIS_PLAYER_NAME="$PLAYER_NAME"
+      echo "   Player override: STELLARIS_PLAYER_NAME=$PLAYER_NAME (from app settings)"
+    fi
+    if [ -n "$PLAYER_CID" ]; then
+      export STELLARIS_PLAYER_COUNTRY_ID="$PLAYER_CID"
+      echo "   Player override: STELLARIS_PLAYER_COUNTRY_ID=$PLAYER_CID (from app settings)"
+    fi
+  fi
+fi
+
 "$PYTHON" -m backend.electron_main &
 
 # Wait for backend to be ready

--- a/electron/main.js
+++ b/electron/main.js
@@ -313,6 +313,17 @@ function buildBackendEnv(settings) {
 
   env.STELLARIS_MODEL_ROUTING_MODE = normalizeModelRoutingMode(settings.modelRoutingMode)
 
+  // Multiplayer player-empire selection. In MP saves the `player` block lists
+  // every human player; without an override the backend defaults to the first
+  // entry (often the host). These let the user pin their own empire.
+  if (settings.playerName) {
+    env.STELLARIS_PLAYER_NAME = String(settings.playerName)
+  }
+  if (settings.playerCountryId !== undefined && settings.playerCountryId !== null
+      && String(settings.playerCountryId).trim() !== '') {
+    env.STELLARIS_PLAYER_COUNTRY_ID = String(settings.playerCountryId).trim()
+  }
+
   // Prefer an explicit directory, otherwise auto-detect a standard location.
   const effectiveSaveDir = getEffectiveSaveDir(settings)
   if (effectiveSaveDir) {
@@ -810,6 +821,8 @@ function getSettings() {
   const discordToken = getSecret(SECRET_STORE_KEYS.discordToken)
 
   const saveDir = store.get('saveDir', '')
+  const playerName = store.get('playerName', '')
+  const playerCountryId = store.get('playerCountryId', '')
   const discordEnabled = store.get('discordEnabled', false)
   const uiScale = getUiScaleSetting()
   const uiTheme = getUiThemeSetting()
@@ -826,6 +839,8 @@ function getSettings() {
     saveDir,
     // Backwards-compat: older renderer builds expect `savePath`.
     savePath: saveDir,
+    playerName,
+    playerCountryId,
     discordEnabled,
     uiScale,
     uiTheme,
@@ -844,6 +859,8 @@ function getSettingsWithSecrets() {
   const googleApiKey = getSecret(SECRET_STORE_KEYS.googleApiKey) || ''
   const discordToken = getSecret(SECRET_STORE_KEYS.discordToken) || ''
   const saveDir = store.get('saveDir', '')
+  const playerName = store.get('playerName', '')
+  const playerCountryId = store.get('playerCountryId', '')
   const lastSaveFilePath = store.get('lastSaveFilePath', '')
   const discordEnabled = store.get('discordEnabled', false)
   const uiScale = getUiScaleSetting()
@@ -859,6 +876,8 @@ function getSettingsWithSecrets() {
     saveDir,
     // Backwards-compat: older renderer builds may still send/expect `savePath`.
     savePath: saveDir,
+    playerName,
+    playerCountryId,
     lastSaveFilePath,
     discordEnabled,
     uiScale,
@@ -890,6 +909,14 @@ function saveSettings(settings) {
     store.set('saveDir', nextSaveDir)
     // Save path changes invalidate any cached "last save file" selection.
     store.set('lastSaveFilePath', '')
+  }
+
+  if (settings.playerName !== undefined) {
+    store.set('playerName', String(settings.playerName || '').trim())
+  }
+
+  if (settings.playerCountryId !== undefined) {
+    store.set('playerCountryId', String(settings.playerCountryId || '').trim())
   }
 
   if (settings.discordEnabled !== undefined) {
@@ -1450,7 +1477,11 @@ registerSettingsIpcHandlers({
       changedSettings.googleApiKey !== undefined ||
       changedSettings.saveDir !== undefined ||
       changedSettings.savePath !== undefined ||
-      changedSettings.modelRoutingMode !== undefined
+      changedSettings.modelRoutingMode !== undefined ||
+      // Player-empire override is read from the backend env at launch, so a
+      // change must restart the backend for it to take effect.
+      changedSettings.playerName !== undefined ||
+      changedSettings.playerCountryId !== undefined
 
     if (backendRelevantSettingsChanged && !E2E_SKIP_BACKEND_AUTOSTART) {
       restartPythonBackend(fullSettings)

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@playwright/test": "^1.54.0",
         "concurrently": "^8.2.2",
+        "cross-env": "^10.1.0",
         "electron": "^28.0.0",
         "electron-builder": "^24.9.0"
       }
@@ -320,6 +321,13 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -709,7 +717,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -903,6 +910,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -922,6 +930,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -944,6 +953,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -959,7 +969,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -967,6 +978,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1076,6 +1088,7 @@
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1461,6 +1474,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1646,6 +1660,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1659,12 +1674,31 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -1867,7 +1901,6 @@
       "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "builder-util": "24.13.1",
@@ -2067,6 +2100,7 @@
       "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "archiver": "^5.3.1",
@@ -2080,6 +2114,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2095,6 +2130,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2108,6 +2144,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2552,7 +2589,8 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -3058,7 +3096,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -3199,6 +3238,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3212,6 +3252,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3227,7 +3268,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3235,6 +3277,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3264,14 +3307,16 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3284,7 +3329,8 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -3298,14 +3344,16 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -3492,6 +3540,7 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3748,7 +3797,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -3832,6 +3882,7 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3847,6 +3898,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -3948,7 +4000,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4166,6 +4219,7 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4281,6 +4335,7 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4469,7 +4524,8 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/verror": {
       "version": "1.10.1",
@@ -4641,6 +4697,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -4656,6 +4713,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:renderer\" \"npm run dev:electron\"",
     "dev:renderer": "cd renderer && npm run dev",
-    "dev:electron": "NODE_ENV=development electron .",
+    "dev:electron": "cross-env NODE_ENV=development electron .",
     "build": "../scripts/build-all.sh",
     "build:renderer": "cd renderer && npm run build",
     "build:electron": "electron-builder",
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@playwright/test": "^1.54.0",
     "concurrently": "^8.2.2",
+    "cross-env": "^10.1.0",
     "electron": "^28.0.0",
     "electron-builder": "^24.9.0"
   }

--- a/electron/renderer/hooks/useSettings.ts
+++ b/electron/renderer/hooks/useSettings.ts
@@ -75,6 +75,11 @@ export interface Settings {
   saveDir: string
   // Deprecated (backwards-compat with older main process / renderer builds)
   savePath?: string
+  // Multiplayer: pin which empire the advisor analyzes. `playerName` matches the
+  // player's name in the save; `playerCountryId` overrides by country ID. Empty
+  // means "use the first player entry" (single-player behavior).
+  playerName: string
+  playerCountryId: string
   discordEnabled: boolean
   uiScale: number
   uiTheme: UiTheme
@@ -119,6 +124,8 @@ export function useSettings(): UseSettingsResult {
       const normalized: Settings = {
         ...loaded,
         saveDir: loaded.saveDir || loaded.savePath || '',
+        playerName: loaded.playerName || '',
+        playerCountryId: loaded.playerCountryId ? String(loaded.playerCountryId) : '',
         uiScale: Number.isFinite(parsedUiScale) ? parsedUiScale : 1,
         uiTheme: normalizeUiTheme(loaded.uiTheme),
         chronicleRefreshMode: normalizeChronicleRefreshMode(loaded.chronicleRefreshMode),

--- a/electron/renderer/i18n/locales/en/common.json
+++ b/electron/renderer/i18n/locales/en/common.json
@@ -280,7 +280,10 @@
     "saveData": {
       "directoryLabel": "DIRECTORY PATH",
       "placeholder": "AUTO-DETECT",
-      "target": "TARGET: STELLARIS SAVE GAME DIRECTORY (LOCAL)"
+      "target": "TARGET: STELLARIS SAVE GAME DIRECTORY (LOCAL)",
+      "playerNameLabel": "MULTIPLAYER PLAYER NAME",
+      "playerNamePlaceholder": "SINGLE-PLAYER (AUTO)",
+      "playerNameHelp": "MULTIPLAYER ONLY: ENTER YOUR PLAYER NAME TO ANALYZE YOUR EMPIRE. LEAVE BLANK FOR SINGLE-PLAYER."
     },
     "discord": {
       "loading": "ESTABLISHING HANDSHAKE...",

--- a/electron/renderer/package-lock.json
+++ b/electron/renderer/package-lock.json
@@ -70,7 +70,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1271,7 +1270,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1451,7 +1449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2002,7 +1999,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -2142,7 +2138,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3031,7 +3026,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3211,7 +3205,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3224,7 +3217,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3663,7 +3655,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3723,7 +3714,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3900,7 +3890,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/electron/renderer/pages/SettingsPage.tsx
+++ b/electron/renderer/pages/SettingsPage.tsx
@@ -101,6 +101,7 @@ function SettingsPage({
 
   const [googleApiKey, setGoogleApiKey] = useState('')
   const [saveDir, setSaveDir] = useState('')
+  const [playerName, setPlayerName] = useState('')
   const [uiScale, setUiScale] = useState(1)
   const [uiScaleSaving, setUiScaleSaving] = useState(false)
   const [uiTheme, setUiTheme] = useState<UiTheme>(DEFAULT_UI_THEME)
@@ -136,6 +137,7 @@ function SettingsPage({
     if (settings) {
       setGoogleApiKey(settings.googleApiKeySet ? settings.googleApiKey : '')
       setSaveDir(settings.saveDir || '')
+      setPlayerName(settings.playerName || '')
       setUiScale(settings.uiScale || 1)
       const normalizedTheme = normalizeUiTheme(settings.uiTheme)
       const normalizedChronicleRefreshMode = normalizeChronicleRefreshMode(
@@ -159,8 +161,9 @@ function SettingsPage({
     if (!settings) return
     const hasApiKeyChange = settings.googleApiKeySet ? googleApiKey !== settings.googleApiKey : googleApiKey !== ''
     const hasPathChange = saveDir !== (settings.saveDir || '')
-    setHasChanges(hasApiKeyChange || hasPathChange)
-  }, [googleApiKey, saveDir, settings])
+    const hasPlayerNameChange = playerName !== (settings.playerName || '')
+    setHasChanges(hasApiKeyChange || hasPathChange || hasPlayerNameChange)
+  }, [googleApiKey, saveDir, playerName, settings])
 
   useEffect(() => {
     let cancelled = false
@@ -189,7 +192,7 @@ function SettingsPage({
 
   const handleSave = async () => {
     setSaveSuccess(false)
-    const settingsToSave: Record<string, string | boolean> = { saveDir }
+    const settingsToSave: Record<string, string | boolean> = { saveDir, playerName }
     if (!googleApiKey.includes('...')) {
       settingsToSave.googleApiKey = googleApiKey
     }
@@ -782,6 +785,17 @@ function SettingsPage({
                              <HUDMicro className="block mt-2">
                                  {t('settings.saveData.target')}
                              </HUDMicro>
+                             <div className="pt-2">
+                                 <HUDInput
+                                    label={t('settings.saveData.playerNameLabel')}
+                                    value={playerName}
+                                    onChange={(e) => setPlayerName(e.target.value)}
+                                    placeholder={t('settings.saveData.playerNamePlaceholder')}
+                                 />
+                                 <HUDMicro className="block mt-2 normal-case">
+                                     {t('settings.saveData.playerNameHelp')}
+                                 </HUDMicro>
+                             </div>
                          </div>
                     </HUDPanel>
                 </section>

--- a/stellaris_save_extractor/base.py
+++ b/stellaris_save_extractor/base.py
@@ -14,6 +14,7 @@ from stellaris_companion.rust_bridge import (
     iter_section_entries,
 )
 
+from .fleet_classification import classify_owned_fleet
 from .name_resolution import ResolvedName
 from .name_resolution import resolve_name as _resolve_name
 
@@ -53,6 +54,8 @@ class SaveExtractorBase:
         self._player_status_cache = None  # Cached player status (expensive to compute)
         self._player_country_entry_cache = None  # Cached player country from Rust get_entry
         self._player_country_content_cache = None  # Cached player country string content
+        self._player_entries_cache = None  # Cached normalized `player` block entries
+        self._player_empire_id_cache = None  # Cached selected player country ID
 
     def close(self) -> None:
         """Release large in-memory state (best-effort)."""
@@ -77,6 +80,8 @@ class SaveExtractorBase:
         self._player_status_cache = None
         self._player_country_entry_cache = None
         self._player_country_content_cache = None
+        self._player_entries_cache = None
+        self._player_empire_id_cache = None
 
     def __enter__(self) -> SaveExtractorBase:
         return self
@@ -897,9 +902,9 @@ class SaveExtractorBase:
             if not isinstance(fleet, dict):
                 continue
 
-            # Direct dict access - no regex needed
-            is_station = fleet.get("station") == "yes"
-            is_civilian = fleet.get("civilian") == "yes"
+            # Classify by ship_class (4.x) with a legacy fallback. In 4.x saves
+            # starbases have ship_class=shipclass_starbase and no station flag.
+            fleet_kind = classify_owned_fleet(fleet)
 
             # Get ship count from ships list/dict
             ships = fleet.get("ships", [])
@@ -912,11 +917,9 @@ class SaveExtractorBase:
             mp = fleet.get("military_power")
             mp = float(mp) if mp is not None else 0.0
 
-            if is_station:
+            if fleet_kind == "starbase":
                 result["starbase_count"] += 1
-            elif is_civilian:
-                result["civilian_fleet_count"] += 1
-            elif mp > 100:  # Threshold filters out space creatures with tiny mp
+            elif fleet_kind == "military":
                 result["military_fleet_count"] += 1
                 result["military_ships"] += ship_count
                 result["total_military_power"] += mp
@@ -1005,6 +1008,27 @@ class SaveExtractorBase:
                     planet_ids.append(planet_id)
 
         return planet_ids
+
+    def _get_player_colony_ids(self) -> list[str]:
+        """Return the player's colony IDs in the pop_group id space.
+
+        Stellaris 4.x pops reference colonies by the country's own colony ids
+        (``owned_planets`` / ``controlled_colonies``), which are a DIFFERENT id
+        space from the top-level ``planets.planet`` section keys. Scanning that
+        section for ``owner == player_id`` (see :meth:`_get_player_planet_ids`)
+        lands on unrelated colonies in 4.x saves and undercounts pops, so prefer
+        the country's own colony list. Falls back to the legacy owner-scan when
+        those fields are absent (older saves).
+        """
+        player_id = self.get_player_empire_id()
+        country = self._get_player_country_entry(player_id)
+        if isinstance(country, dict):
+            for field in ("owned_planets", "controlled_colonies"):
+                ids = country.get(field)
+                if isinstance(ids, list) and ids:
+                    return [str(x) for x in ids]
+
+        return [str(x) for x in self._get_player_planet_ids()]
 
     def _get_pop_ids_for_planets(self, planet_ids: list[str]) -> list[str]:
         """Get all pop IDs from the specified planets.

--- a/stellaris_save_extractor/economy.py
+++ b/stellaris_save_extractor/economy.py
@@ -187,8 +187,10 @@ class EconomyMixin:
             "unemployed_pops": 0,
         }
 
-        # Step 1: Get player's planet IDs (as set of strings for comparison)
-        planet_ids = self._get_player_planet_ids()
+        # Step 1: Get the player's colony IDs. Pops reference colonies by the
+        # country's own colony id space (owned_planets/controlled_colonies),
+        # which differs from the planets.planet section keys in 4.x saves.
+        planet_ids = self._get_player_colony_ids()
         if not planet_ids:
             return result
 

--- a/stellaris_save_extractor/fleet_classification.py
+++ b/stellaris_save_extractor/fleet_classification.py
@@ -1,0 +1,57 @@
+"""Classify a player's owned fleets as military, starbase, or civilian.
+
+Stellaris 4.x ("Pegasus") tags every fleet with a ``ship_class`` (e.g.
+``shipclass_military``, ``shipclass_starbase``, ``shipclass_science_ship``) and
+no longer marks starbases with ``station=yes``. The old heuristic
+(``station``/``civilian`` flags plus a military-power threshold) therefore
+counted every starbase as a military fleet. Prefer the explicit ``ship_class``
+when present; fall back to the legacy heuristic for older saves that lack it.
+"""
+
+from __future__ import annotations
+
+MILITARY_SHIP_CLASS = "shipclass_military"
+STARBASE_SHIP_CLASS = "shipclass_starbase"
+
+# Non-combat owned fleets in 4.x saves (science/construction/orbital stations).
+CIVILIAN_SHIP_CLASSES = frozenset(
+    {
+        "shipclass_science_ship",
+        "shipclass_constructor",
+        "shipclass_colonizer",
+        "shipclass_transport",
+        "shipclass_mining_station",
+        "shipclass_research_station",
+        "shipclass_observation_station",
+    }
+)
+
+
+def classify_owned_fleet(fleet_data: dict, *, military_power_threshold: float = 100.0) -> str:
+    """Return ``"military"``, ``"starbase"``, or ``"civilian"`` for one fleet.
+
+    Args:
+        fleet_data: A parsed fleet entry from the gamestate ``fleet`` section.
+        military_power_threshold: Legacy-only cutoff used when a fleet has no
+            ``ship_class`` and no ``station``/``civilian`` markers (filters out
+            tiny space-fauna fleets).
+    """
+    ship_class = fleet_data.get("ship_class")
+    if ship_class == STARBASE_SHIP_CLASS:
+        return "starbase"
+    if ship_class == MILITARY_SHIP_CLASS:
+        return "military"
+    if ship_class in CIVILIAN_SHIP_CLASSES:
+        return "civilian"
+
+    # Legacy saves (or unrecognized ship_class): fall back to the old heuristic.
+    if fleet_data.get("station") == "yes":
+        return "starbase"
+    if fleet_data.get("civilian") == "yes":
+        return "civilian"
+
+    try:
+        military_power = float(fleet_data.get("military_power", "0") or 0)
+    except (ValueError, TypeError):
+        military_power = 0.0
+    return "military" if military_power > military_power_threshold else "civilian"

--- a/stellaris_save_extractor/military.py
+++ b/stellaris_save_extractor/military.py
@@ -7,6 +7,8 @@ import re
 # Rust bridge for fast Clausewitz parsing - session mode required
 from stellaris_companion.rust_bridge import ParserError, _get_active_session
 
+from .fleet_classification import classify_owned_fleet
+
 logger = logging.getLogger(__name__)
 
 
@@ -437,9 +439,10 @@ class MilitaryMixin:
             if fleet_id not in owned_set:
                 continue
 
-            # Check if station or civilian
-            is_station = fleet_data.get("station") == "yes"
-            is_civilian = fleet_data.get("civilian") == "yes"
+            # Classify by ship_class (4.x) with a legacy fallback. In 4.x saves
+            # starbases are ship_class=shipclass_starbase with no station flag,
+            # so the old station/power heuristic counted them as military.
+            fleet_kind = classify_owned_fleet(fleet_data)
 
             # Get military power
             mp_str = fleet_data.get("military_power", "0")
@@ -452,12 +455,10 @@ class MilitaryMixin:
             ships = fleet_data.get("ships", [])
             ship_count = len(ships) if isinstance(ships, list) else 0
 
-            if is_station:
+            if fleet_kind == "starbase":
                 # Stations are counted separately via _count_player_starbases
                 pass
-            elif is_civilian:
-                civilian_count += 1
-            elif mp > 100:  # Threshold filters out space creatures with tiny mp
+            elif fleet_kind == "military":
                 # Extract fleet name
                 name_block = fleet_data.get("name")
                 fleet_name = self._resolve_fleet_name(name_block, fleet_id)
@@ -574,19 +575,9 @@ class MilitaryMixin:
             if fleet_id not in owned_set:
                 continue
 
-            # Skip stations and civilian fleets
-            if fleet_data.get("station") == "yes":
-                continue
-            if fleet_data.get("civilian") == "yes":
-                continue
-
-            # Check military power threshold
-            mp_str = fleet_data.get("military_power", "0")
-            try:
-                military_power = float(mp_str)
-            except (ValueError, TypeError):
-                military_power = 0.0
-            if military_power <= 100:
+            # Skip starbases and civilian fleets (ship_class-aware; 4.x starbases
+            # have no station flag). Only combat fleets contribute to composition.
+            if classify_owned_fleet(fleet_data) != "military":
                 continue
 
             # Get fleet name

--- a/stellaris_save_extractor/player.py
+++ b/stellaris_save_extractor/player.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import re
 from collections import Counter, defaultdict
 
@@ -9,6 +10,106 @@ from collections import Counter, defaultdict
 from stellaris_companion.rust_bridge import ParserError, _get_active_session
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_player_entries(player_list) -> list[dict]:
+    """Normalize a save's ``player`` block into ``[{"country": int, "name": str}]``.
+
+    Stellaris stores one entry per human player. Multiplayer saves have several;
+    single-player saves have exactly one. Country IDs come through as strings and
+    the block may occasionally be surfaced as an index-keyed dict, so both shapes
+    are handled. Malformed entries (missing/non-numeric country) are skipped.
+    """
+    if isinstance(player_list, dict):
+        player_list = list(player_list.values())
+    if not isinstance(player_list, list):
+        return []
+
+    entries: list[dict] = []
+    for item in player_list:
+        if not isinstance(item, dict):
+            continue
+        raw_country = item.get("country")
+        if raw_country is None:
+            continue
+        try:
+            country_id = int(raw_country)
+        except (ValueError, TypeError):
+            continue
+        name = item.get("name")
+        entries.append({"country": country_id, "name": name if isinstance(name, str) else ""})
+    return entries
+
+
+def _select_player_country_id(
+    entries: list[dict],
+    *,
+    override_country_id: int | None = None,
+    override_name: str | None = None,
+) -> tuple[int, dict]:
+    """Choose the player's country ID from the normalized ``player`` entries.
+
+    Priority (per the multiplayer selection fix):
+      1. Explicit ``override_country_id`` (from backend config).
+      2. Explicit ``override_name`` matched against the players' names
+         (case/whitespace-insensitive).
+      3. A single entry (single-player) -> that entry, no warning.
+      4. Fallback to the first entry (legacy behavior) -- the caller logs a
+         warning listing every candidate so users can set an override.
+
+    Returns ``(country_id, info)`` where ``info["method"]`` is one of
+    ``country_id_override``, ``name_override``, ``single``, ``first_fallback``,
+    or ``empty``, and ``info["candidates"]`` holds the normalized entries.
+    """
+    info: dict = {"method": "empty", "candidates": entries}
+
+    if not entries:
+        return 0, info
+
+    if override_country_id is not None:
+        info["method"] = "country_id_override"
+        info["matched"] = any(e["country"] == override_country_id for e in entries)
+        return override_country_id, info
+
+    if override_name:
+        target = override_name.strip().casefold()
+        for entry in entries:
+            if entry["name"].strip().casefold() == target:
+                info["method"] = "name_override"
+                return entry["country"], info
+        # No match -> record it so the caller can warn, then fall through.
+        info["override_name_unmatched"] = override_name
+
+    if len(entries) == 1:
+        info["method"] = "single"
+        return entries[0]["country"], info
+
+    info["method"] = "first_fallback"
+    return entries[0]["country"], info
+
+
+def _get_player_override() -> tuple[int | None, str | None]:
+    """Read the player-empire override from backend settings (environment vars).
+
+    ``STELLARIS_PLAYER_COUNTRY_ID`` selects by country ID; ``STELLARIS_PLAYER_NAME``
+    selects by the local player's name. Both are optional and only matter for
+    multiplayer saves.
+    """
+    country_id: int | None = None
+    raw_id = os.environ.get("STELLARIS_PLAYER_COUNTRY_ID")
+    if raw_id and raw_id.strip():
+        try:
+            country_id = int(raw_id.strip())
+        except ValueError:
+            logger.warning(
+                "Ignoring invalid STELLARIS_PLAYER_COUNTRY_ID=%r (expected an integer)",
+                raw_id,
+            )
+
+    name = os.environ.get("STELLARIS_PLAYER_NAME")
+    if name is not None:
+        name = name.strip() or None
+    return country_id, name
 
 _BASE_NAVAL_CAP = 50.0
 
@@ -170,8 +271,37 @@ class PlayerMixin:
 
         return deduped
 
+    def _get_player_entries(self) -> list[dict]:
+        """Return the normalized ``player`` block, cached per extraction.
+
+        Requires Rust session mode to be active.
+        """
+        cached = getattr(self, "_player_entries_cache", None)
+        if cached is not None:
+            return cached
+
+        session = _get_active_session()
+        if not session:
+            raise ParserError("Rust session required - use 'with session(save_path):' context")
+
+        data = session.extract_sections(["player"])
+        entries = _normalize_player_entries(data.get("player", []))
+        self._player_entries_cache = entries
+        return entries
+
+    def is_multiplayer_save(self) -> bool:
+        """True when the save records more than one human player."""
+        return len(self._get_player_entries()) > 1
+
     def get_player_empire_id(self) -> int:
         """Get the player's country ID.
+
+        For multiplayer saves the ``player`` block lists every human player; the
+        old logic always took the first entry (usually the host), so the wrong
+        empire was analyzed. Selection now honors an explicit backend override
+        (``STELLARIS_PLAYER_COUNTRY_ID`` / ``STELLARIS_PLAYER_NAME``), then falls
+        back to the first entry with a warning. Single-player saves (one entry)
+        are unaffected. The result is cached per extraction.
 
         Requires Rust session mode to be active.
 
@@ -181,16 +311,91 @@ class PlayerMixin:
         Raises:
             ParserError: If no Rust session is active
         """
+        cached = getattr(self, "_player_empire_id_cache", None)
+        if cached is not None:
+            return cached
+
+        entries = self._get_player_entries()
+        override_country_id, override_name = _get_player_override()
+        country_id, info = _select_player_country_id(
+            entries,
+            override_country_id=override_country_id,
+            override_name=override_name,
+        )
+        self._log_player_selection(country_id, info)
+        self._player_empire_id_cache = country_id
+        return country_id
+
+    def _log_player_selection(self, country_id: int, info: dict) -> None:
+        """Emit a helpful log line describing which player empire was chosen."""
+        method = info.get("method")
+        if method in (None, "empty", "single"):
+            return
+
+        if info.get("override_name_unmatched"):
+            logger.warning(
+                "STELLARIS_PLAYER_NAME=%r did not match any player in this save; "
+                "falling back to country %s. Players: %s",
+                info["override_name_unmatched"],
+                country_id,
+                self._describe_player_candidates(info.get("candidates", [])),
+            )
+            return
+
+        if method == "first_fallback":
+            logger.warning(
+                "Multiplayer save: %d player empires found and no player override "
+                "configured; defaulting to the first entry (country %s). Set "
+                "STELLARIS_PLAYER_NAME or STELLARIS_PLAYER_COUNTRY_ID to pick your "
+                "empire. Players: %s",
+                len(info.get("candidates", [])),
+                country_id,
+                self._describe_player_candidates(info.get("candidates", [])),
+            )
+        elif method in ("name_override", "country_id_override"):
+            logger.info(
+                "Selected player empire via %s -> country %s.", method, country_id
+            )
+
+    def _describe_player_candidates(self, candidates: list[dict]) -> str:
+        """Build a readable 'player -> country (empire name)' listing for logs."""
+        parts = []
+        for cand in candidates:
+            cid = cand.get("country")
+            empire = self._resolve_country_empire_name(cid)
+            label = f"player '{cand.get('name')}' -> country {cid}"
+            if empire:
+                label += f" ({empire})"
+            parts.append(label)
+        return "; ".join(parts)
+
+    def _resolve_country_empire_name(self, country_id) -> str | None:
+        """Best-effort resolved empire name for a country ID (used for logging)."""
         session = _get_active_session()
         if not session:
-            raise ParserError("Rust session required - use 'with session(save_path):' context")
+            return None
+        with contextlib.suppress(Exception):
+            entry = session.get_entry("country", str(country_id))
+            if isinstance(entry, dict) and entry.get("name") is not None:
+                return self.resolve_name(
+                    entry["name"], default="", context="country"
+                ).display or None
+        return None
 
-        data = session.extract_sections(["player"])
-        player_list = data.get("player", [])
-        if player_list and isinstance(player_list, list) and len(player_list) > 0:
-            country_id = player_list[0].get("country", "0")
-            return int(country_id)
-        return 0
+    def get_player_empire_name(self) -> str:
+        """Resolve the selected player's empire name.
+
+        In multiplayer the ``meta`` header name reflects whoever saved the game
+        (often the host), so it can't be trusted as the local player's empire.
+        For multiplayer saves the name is resolved from the *selected* country's
+        block; single-player saves keep the existing meta-derived name.
+        """
+        meta_name = self.get_metadata().get("name", "Unknown")
+        if not self.is_multiplayer_save():
+            return meta_name
+
+        resolved = self._resolve_country_empire_name(self.get_player_empire_id())
+        return resolved or meta_name
 
     def get_player_status(self) -> dict:
         """Get the player's current empire status with clear, unambiguous metrics.
@@ -233,7 +438,7 @@ class PlayerMixin:
 
         result = {
             "player_id": player_id,
-            "empire_name": self.get_metadata().get("name", "Unknown"),
+            "empire_name": self.get_player_empire_name(),
             "date": self.get_metadata().get("date", "Unknown"),
         }
 
@@ -292,7 +497,18 @@ class PlayerMixin:
         # Get colonized planets data (already uses Rust when session active)
         planets_data = self.get_planets()
         colonies = planets_data.get("planets", [])
-        total_pops = sum(p.get("population", 0) for p in colonies)
+        summed_pops = sum(p.get("population", 0) for p in colonies)
+
+        # Prefer the empire's authoritative pop count. In 4.x saves the
+        # per-colony population from get_planets can resolve against the wrong
+        # planet-id space (see _get_player_colony_ids); num_sapient_pops is the
+        # game's own figure and matches the in-game Species panel.
+        total_pops = summed_pops
+        if isinstance(player_country, dict):
+            raw_pops = player_country.get("num_sapient_pops")
+            if raw_pops is not None:
+                with contextlib.suppress(ValueError, TypeError):
+                    total_pops = int(raw_pops)
 
         # Separate habitats from planets (different pop capacities)
         habitats = [c for c in colonies if c.get("type", "").startswith("habitat")]
@@ -348,7 +564,7 @@ class PlayerMixin:
             "is_gestalt": False,
             "is_machine": False,
             "is_hive_mind": False,
-            "empire_name": self.get_metadata().get("name", "Unknown"),
+            "empire_name": self.get_player_empire_name(),
         }
 
         # Rust session required

--- a/tests/test_fleet_classification.py
+++ b/tests/test_fleet_classification.py
@@ -1,0 +1,68 @@
+"""Tests for owned-fleet classification (Stellaris 4.x + legacy saves).
+
+Stellaris 4.x ("Pegasus") tags every fleet with a ``ship_class`` and dropped the
+old ``station=yes`` marker, so starbases (``shipclass_starbase``) were being
+counted as military fleets/ships. Classification must key off ``ship_class`` when
+present and fall back to the legacy ``station``/``civilian``/military-power
+heuristic for older saves.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from stellaris_save_extractor.fleet_classification import classify_owned_fleet
+
+
+def test_starbase_ship_class_is_starbase_even_without_station_flag():
+    # 4.x starbase: no `station` field, single ship, non-trivial military power.
+    fleet = {"ship_class": "shipclass_starbase", "military_power": "303", "ships": ["1"]}
+    assert classify_owned_fleet(fleet) == "starbase"
+
+
+def test_military_ship_class_is_military():
+    fleet = {"ship_class": "shipclass_military", "military_power": "1233", "ships": ["1", "2"]}
+    assert classify_owned_fleet(fleet) == "military"
+
+
+def test_low_power_military_class_still_counts_as_military():
+    # A battered fleet with low power is still military when ship_class says so.
+    fleet = {"ship_class": "shipclass_military", "military_power": "12", "ships": ["1"]}
+    assert classify_owned_fleet(fleet) == "military"
+
+
+def test_civilian_ship_classes_are_civilian():
+    for cls in (
+        "shipclass_science_ship",
+        "shipclass_constructor",
+        "shipclass_mining_station",
+        "shipclass_research_station",
+        "shipclass_observation_station",
+    ):
+        fleet = {"ship_class": cls, "military_power": "0"}
+        assert classify_owned_fleet(fleet) == "civilian", cls
+
+
+def test_legacy_station_flag_is_starbase():
+    fleet = {"station": "yes", "military_power": "303"}
+    assert classify_owned_fleet(fleet) == "starbase"
+
+
+def test_legacy_civilian_flag_is_civilian():
+    fleet = {"civilian": "yes", "military_power": "0"}
+    assert classify_owned_fleet(fleet) == "civilian"
+
+
+def test_legacy_no_markers_uses_power_threshold():
+    assert classify_owned_fleet({"military_power": "500"}) == "military"
+    assert classify_owned_fleet({"military_power": "50"}) == "civilian"
+
+
+def test_unknown_ship_class_falls_back_to_legacy_heuristic():
+    # Unknown/future class with no station flag: treat by power heuristic.
+    assert classify_owned_fleet({"ship_class": "shipclass_future", "military_power": "500"}) == "military"
+    # ...but a legacy station flag still wins.
+    assert (
+        classify_owned_fleet({"ship_class": "shipclass_future", "station": "yes"}) == "starbase"
+    )

--- a/tests/test_player_selection.py
+++ b/tests/test_player_selection.py
@@ -1,0 +1,221 @@
+"""Tests for multiplayer player-empire selection.
+
+A Stellaris multiplayer save's gamestate has a `player` block with one entry
+per human player, each ``{ name = "<player>", country = <country_id> }``. The
+old logic always took the first entry (usually the host), so multiplayer saves
+were analyzed as the host's empire. These tests cover the selection logic that
+picks the right empire from an explicit override, the local player name, or a
+logged first-entry fallback.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from stellaris_save_extractor.player import (
+    _normalize_player_entries,
+    _select_player_country_id,
+)
+
+# Minimal multi-entry player block, mirroring the real MP autosave:
+#   country 0 = "Will-O-Matic", country 1 = "Flame"
+MP_PLAYER_BLOCK = [
+    {"country": "0", "name": "Will-O-Matic"},
+    {"country": "1", "name": "Flame"},
+]
+
+SP_PLAYER_BLOCK = [{"country": "0", "name": "Will-O-Matic"}]
+
+
+def test_normalize_coerces_country_ids_to_int_and_keeps_names():
+    entries = _normalize_player_entries(MP_PLAYER_BLOCK)
+    assert entries == [
+        {"country": 0, "name": "Will-O-Matic"},
+        {"country": 1, "name": "Flame"},
+    ]
+
+
+def test_normalize_handles_dict_shaped_player_block():
+    # Some parses can surface the block as a dict keyed by index.
+    block = {"0": {"country": "0", "name": "Host"}, "1": {"country": "5", "name": "Guest"}}
+    entries = _normalize_player_entries(block)
+    assert {"country": 0, "name": "Host"} in entries
+    assert {"country": 5, "name": "Guest"} in entries
+
+
+def test_normalize_skips_malformed_entries():
+    block = [{"name": "no country"}, "junk", {"country": "2", "name": "ok"}]
+    assert _normalize_player_entries(block) == [{"country": 2, "name": "ok"}]
+
+
+def test_single_player_returns_first_without_fallback_warning():
+    entries = _normalize_player_entries(SP_PLAYER_BLOCK)
+    country_id, info = _select_player_country_id(entries)
+    assert country_id == 0
+    assert info["method"] == "single"
+
+
+def test_name_override_selects_matching_empire():
+    entries = _normalize_player_entries(MP_PLAYER_BLOCK)
+    country_id, info = _select_player_country_id(entries, override_name="Will-O-Matic")
+    assert country_id == 0
+    assert info["method"] == "name_override"
+
+    country_id, info = _select_player_country_id(entries, override_name="Flame")
+    assert country_id == 1
+    assert info["method"] == "name_override"
+
+
+def test_name_override_is_case_and_whitespace_insensitive():
+    entries = _normalize_player_entries(MP_PLAYER_BLOCK)
+    country_id, info = _select_player_country_id(entries, override_name="  will-o-matic ")
+    assert country_id == 0
+    assert info["method"] == "name_override"
+
+
+def test_country_id_override_takes_priority_over_name():
+    entries = _normalize_player_entries(MP_PLAYER_BLOCK)
+    country_id, info = _select_player_country_id(
+        entries, override_country_id=1, override_name="Will-O-Matic"
+    )
+    assert country_id == 1
+    assert info["method"] == "country_id_override"
+
+
+def test_name_override_no_match_falls_back_to_first_entry():
+    entries = _normalize_player_entries(MP_PLAYER_BLOCK)
+    country_id, info = _select_player_country_id(entries, override_name="Nonexistent")
+    assert country_id == 0
+    assert info["method"] == "first_fallback"
+
+
+def test_multiplayer_no_override_falls_back_to_first_with_candidates_listed():
+    entries = _normalize_player_entries(MP_PLAYER_BLOCK)
+    country_id, info = _select_player_country_id(entries)
+    assert country_id == 0
+    assert info["method"] == "first_fallback"
+    # Fallback must expose every candidate so a warning can list them.
+    assert info["candidates"] == entries
+
+
+def test_empty_player_block_returns_zero():
+    country_id, info = _select_player_country_id([])
+    assert country_id == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: exercise the real get_player_empire_id / get_player_empire_name
+# methods (env override + name threading) against an injected fake session, so
+# the wiring is regression-protected without needing a real multiplayer save.
+# ---------------------------------------------------------------------------
+
+import contextlib
+
+import pytest
+
+from stellaris_companion import rust_bridge
+from stellaris_save_extractor.base import SaveExtractorBase
+from stellaris_save_extractor.player import PlayerMixin
+
+# Custom empire names are stored as literal name blocks in the save.
+COUNTRY_ENTRIES = {
+    "0": {"name": {"key": "Great Coffee Nation", "literal": "yes"}},
+    "1": {"name": {"key": "Omnivorous Cevantian Swarm", "literal": "yes"}},
+}
+
+
+class _FakeSession:
+    def __init__(self, players, countries):
+        self._players = players
+        self._countries = countries
+        self.extract_calls = 0
+
+    def extract_sections(self, sections):
+        if "player" in sections:
+            self.extract_calls += 1
+            return {"player": self._players}
+        return {}
+
+    def get_entry(self, section, key):
+        if section == "country":
+            return self._countries.get(str(key))
+        return None
+
+
+class _FakeExtractor(PlayerMixin, SaveExtractorBase):
+    """Minimal extractor that skips file I/O but keeps real selection logic."""
+
+    def __init__(self, meta_name="mp_host_save"):
+        self._meta_name = meta_name
+        self._player_entries_cache = None
+        self._player_empire_id_cache = None
+        self._player_country_entry_cache = None
+
+    def get_metadata(self):  # override: avoid reading a real save's meta zip
+        return {"name": self._meta_name}
+
+
+@contextlib.contextmanager
+def _injected_session(session):
+    prev = getattr(rust_bridge._tls, "session", None)
+    rust_bridge._tls.session = session
+    try:
+        yield
+    finally:
+        rust_bridge._tls.session = prev
+
+
+@pytest.fixture(autouse=True)
+def _clear_override_env(monkeypatch):
+    monkeypatch.delenv("STELLARIS_PLAYER_NAME", raising=False)
+    monkeypatch.delenv("STELLARIS_PLAYER_COUNTRY_ID", raising=False)
+
+
+def test_name_override_threads_selected_empire_name(monkeypatch):
+    monkeypatch.setenv("STELLARIS_PLAYER_NAME", "Will-O-Matic")
+    session = _FakeSession(
+        [{"country": "0", "name": "Host"}, {"country": "1", "name": "Will-O-Matic"}],
+        COUNTRY_ENTRIES,
+    )
+    with _injected_session(session):
+        ext = _FakeExtractor()
+        assert ext.get_player_empire_id() == 1
+        name = ext.get_player_empire_name()
+        # Name comes from the selected country's block, not the meta header.
+        assert name == ext._resolve_country_empire_name(1)
+        assert name != ext.get_metadata()["name"]
+
+
+def test_country_id_override_threads_selected_empire(monkeypatch):
+    monkeypatch.setenv("STELLARIS_PLAYER_COUNTRY_ID", "1")
+    session = _FakeSession(
+        [{"country": "0", "name": "Host"}, {"country": "1", "name": "Guest"}],
+        COUNTRY_ENTRIES,
+    )
+    with _injected_session(session):
+        ext = _FakeExtractor()
+        assert ext.get_player_empire_id() == 1
+
+
+def test_multiplayer_fallback_still_returns_first_and_caches(monkeypatch):
+    session = _FakeSession(
+        [{"country": "0", "name": "Host"}, {"country": "1", "name": "Guest"}],
+        COUNTRY_ENTRIES,
+    )
+    with _injected_session(session):
+        ext = _FakeExtractor()
+        assert ext.get_player_empire_id() == 0
+        # Repeated calls must not re-query the session.
+        ext.get_player_empire_id()
+        ext.get_player_empire_id()
+        assert session.extract_calls == 1
+
+
+def test_single_player_name_falls_back_to_meta_name():
+    session = _FakeSession([{"country": "0", "name": "SoloPlayer"}], COUNTRY_ENTRIES)
+    with _injected_session(session):
+        ext = _FakeExtractor(meta_name="United Nations of Earth")
+        assert ext.is_multiplayer_save() is False
+        # Single-player keeps the existing meta-derived name (unchanged behavior).
+        assert ext.get_player_empire_name() == "United Nations of Earth"

--- a/tests/test_pop_colony_ids.py
+++ b/tests/test_pop_colony_ids.py
@@ -1,0 +1,52 @@
+"""Tests for player colony-id selection (Stellaris 4.x pop counting).
+
+Stellaris 4.x pops reference colonies by the country's own colony ids
+(``owned_planets``/``controlled_colonies``), which are a DIFFERENT id space from
+the top-level ``planets.planet`` section keys. Scanning that section for
+``owner==player_id`` lands on the wrong colonies (undercounting pops), so pop
+statistics must select colonies from the country's colony list.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from stellaris_save_extractor.base import SaveExtractorBase
+
+
+class _Dummy(SaveExtractorBase):
+    """Minimal base double: stubs the two dependencies of _get_player_colony_ids."""
+
+    def __init__(self, country_entry, legacy_ids=None):
+        self._country_entry = country_entry
+        self._legacy_ids = legacy_ids or []
+
+    def get_player_empire_id(self):
+        return 1
+
+    def _get_player_country_entry(self, player_id=0):
+        return self._country_entry
+
+    def _get_player_planet_ids(self):
+        return self._legacy_ids
+
+
+def test_prefers_owned_planets_colony_ids():
+    ext = _Dummy({"owned_planets": ["1", "62"]}, legacy_ids=["24", "325"])
+    assert ext._get_player_colony_ids() == ["1", "62"]
+
+
+def test_falls_back_to_controlled_colonies():
+    ext = _Dummy({"controlled_colonies": ["3", "9"]}, legacy_ids=["24"])
+    assert ext._get_player_colony_ids() == ["3", "9"]
+
+
+def test_falls_back_to_legacy_owner_scan_when_no_colony_fields():
+    ext = _Dummy({}, legacy_ids=["24", "325"])
+    assert ext._get_player_colony_ids() == ["24", "325"]
+
+
+def test_coerces_ids_to_strings():
+    ext = _Dummy({"owned_planets": [1, 62]})
+    assert ext._get_player_colony_ids() == ["1", "62"]


### PR DESCRIPTION
## Description

Three fixes for Stellaris 4.x **"Pegasus"** saves, where data-model changes broke multiplayer analysis and empire stat extraction. All verified against real saves at the extraction layer; single-player behavior is unchanged.

**1. Multiplayer player-empire selection.** MP saves were previously always analyzed as the host's (saver's) empire — the code took the first entry of the gamestate `player` block and read the empire name from the `meta` header. Now the player empire is selected via **explicit override → local player name → logged first-entry fallback**, with the empire name resolved from the *selected* country. Adds pure helpers in `player.py` (`_normalize_player_entries`, `_select_player_country_id`, `_get_player_override` reading env `STELLARIS_PLAYER_COUNTRY_ID` / `STELLARIS_PLAYER_NAME`), `is_multiplayer_save()`, `get_player_empire_name()`, plus a "Multiplayer player name" setting threaded through `electron/main.js`, `useSettings.ts`, `SettingsPage.tsx`, and `dev.sh`.

**2. Starbases counted as military fleets.** In 4.x, starbase fleets no longer carry `station=yes`; every fleet has a `ship_class`. The old station-flag check never matched, so single-ship starbases were counted as military.
- Before: `military_fleets=21`, `military_ships=42`, `total_military_power=11454`
- After: `military_fleets=2`, `military_ships=23` (corvettes), `total_military_power=2553` ✅
- New `fleet_classification.classify_owned_fleet()` keys off `ship_class` with a legacy station/civilian/power fallback; wired into `military.py` and `base.py`.

**3. Pop undercount.** 4.x pops reference colonies by the country's own colony ids (`owned_planets` / `controlled_colonies`), a different id-space from the top-level `planets.planet` section keys. Scanning that section for `owner==player_id` landed on the wrong colonies.
- Before: 1,800 pops · After: 6,400 pops ✅ (matches the in-game Species panel), with correct species/stratum breakdown.
- New `base._get_player_colony_ids()`; `economy.py` selects via colony ids; `player.py` uses the authoritative `num_sapient_pops` for total population.

## Related issue
Related to #31 (per-colony enumeration follow-up) and #32 (broader 4.x compatibility audit). This PR does not fully close either — it fixes pop totals/breakdown but leaves per-colony enumeration for #31.

## Priority alignment
- [x] This PR aligns with current priorities: DLC coverage/correctness, Windows/Linux reliability, or stability of existing features
- [x] If this is a new feature, I explained why it is critical right now

The core work is correctness fixes for 4.x saves. The one new user-facing element — the "Multiplayer player name" setting — is what makes correct empire selection controllable in MP (where name/id can't always be auto-detected); without it, MP briefings silently analyze the wrong empire.

## DLC impact
- [x] No DLC behavior changed
- [ ] DLC behavior changed; affected DLC(s) are listed in the PR description

Changes target base-game 4.x gamestate shapes (fleets, pops, player block); no DLC-specific behavior touched.

## Platform validation
- [x] I tested on Windows and/or Linux, or explained why that was not possible

Extraction verified on Windows 11 (Python 3.12) via the full test suite and real-save runs. **The full Electron app and a live in-game session have not yet been exercised end-to-end — that validation is still pending (see Testing status).**

## Regression risk
Single-player is unchanged: selection falls back to the single/first entry and the `meta` name, and all new classification/colony-id logic preserves the pre-4.x path (legacy `station`/`civilian`/power fleet heuristic and `owner==player_id` colony scan) as an explicit fallback. Risk is concentrated in fleet classification and colony-id selection; both are covered by new unit tests plus real-save extraction verification against known ground-truth numbers.

## Testing status
**Verified (automated / extraction layer):**
- `pytest tests/` — 241 passed, 20 skipped (+22 new tests)
- Rust parser builds clean (no Rust changes)
- Real MP `.sav` files parsed and compared to in-game ground truth: correct empire selected under name/id overrides and fallback; military 2 fleets / 23 ships / 2553 power; pops 6,400 with correct species/strata.

**Pending (in the running game — author validation):**
- Electron Settings → "Multiplayer player name" round-trip: save persists and backend restarts with the new env.
- Live in-game session: briefing/advisor identifies the correct player empire (not the host), with correct name, pop count, and military figures shown in the app UI.
- No-override fallback path in-app: warning logged and first empire used.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation

## Checklist
- [x] Tests pass locally (`pytest tests/`) — 241 passed, 20 skipped (+22 new tests)
- [x] Rust parser builds (`cd stellaris-parser && cargo build --release`) — no Rust changes; builds clean
- [x] No new warnings — the single pytest warning is a pre-existing Starlette deprecation, unrelated to this PR
- [x] I have tested with a real Stellaris save file — extraction verified against real MP saves with ground-truth comparison. **In-app / live-game validation still pending (see Testing status).**