### PR TITLE
fix: correct leader and known-empire counts for Stellaris 4.x saves

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -53,11 +53,13 @@ cleanup_orphans
 # Start Python backend in background (use venv if available)
 echo "📦 Starting Python backend on :8742..."
 if [ -f "venv/bin/python3" ]; then
-  venv/bin/python3 -m backend.electron_main &
+  PYTHON="venv/bin/python3"
+elif [ -f "venv/Scripts/python.exe" ]; then
+  PYTHON="venv/Scripts/python.exe"
 else
-  python3 -m backend.electron_main &
+  PYTHON="${PYTHON:-python3}"
 fi
-PYTHON_PID=$!
+"$PYTHON" -m backend.electron_main &
 
 # Wait for backend to be ready
 echo "⏳ Waiting for backend..."

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@playwright/test": "^1.54.0",
         "concurrently": "^8.2.2",
+        "cross-env": "^10.1.0",
         "electron": "^28.0.0",
         "electron-builder": "^24.9.0"
       }
@@ -320,6 +321,13 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -709,7 +717,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -903,6 +910,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -922,6 +930,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -944,6 +953,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -959,7 +969,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -967,6 +978,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1076,6 +1088,7 @@
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1461,6 +1474,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -1646,6 +1660,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1659,12 +1674,31 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -1867,7 +1901,6 @@
       "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "builder-util": "24.13.1",
@@ -2067,6 +2100,7 @@
       "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "24.13.3",
         "archiver": "^5.3.1",
@@ -2080,6 +2114,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2095,6 +2130,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2108,6 +2144,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2552,7 +2589,8 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -3058,7 +3096,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -3199,6 +3238,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3212,6 +3252,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3227,7 +3268,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3235,6 +3277,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3264,14 +3307,16 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -3284,7 +3329,8 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -3298,14 +3344,16 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -3492,6 +3540,7 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3748,7 +3797,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -3832,6 +3882,7 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3847,6 +3898,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -3948,7 +4000,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4166,6 +4219,7 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4281,6 +4335,7 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4469,7 +4524,8 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/verror": {
       "version": "1.10.1",
@@ -4641,6 +4697,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -4656,6 +4713,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:renderer\" \"npm run dev:electron\"",
     "dev:renderer": "cd renderer && npm run dev",
-    "dev:electron": "NODE_ENV=development electron .",
+    "dev:electron": "cross-env NODE_ENV=development electron .",
     "build": "../scripts/build-all.sh",
     "build:renderer": "cd renderer && npm run build",
     "build:electron": "electron-builder",
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@playwright/test": "^1.54.0",
     "concurrently": "^8.2.2",
+    "cross-env": "^10.1.0",
     "electron": "^28.0.0",
     "electron-builder": "^24.9.0"
   }

--- a/electron/renderer/package-lock.json
+++ b/electron/renderer/package-lock.json
@@ -70,7 +70,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1271,7 +1270,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1451,7 +1449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2002,7 +1999,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -2142,7 +2138,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3031,7 +3026,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3211,7 +3205,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3224,7 +3217,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3663,7 +3655,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3723,7 +3714,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3900,7 +3890,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/stellaris_save_extractor/base.py
+++ b/stellaris_save_extractor/base.py
@@ -343,6 +343,23 @@ class SaveExtractorBase:
 
         return None
 
+    def _get_player_owned_leader_ids(self) -> set[str] | None:
+        """Authoritative set of the player's *hired* leader IDs.
+
+        Stellaris 4.x tags recruitment-pool candidates with the player's country,
+        so scanning the ``leaders`` section by country over-counts. The country's
+        ``owned_leaders`` list is the real hired-leader roster (matches the in-game
+        Leaders screen). Returns ``None`` when the field is absent (older saves), so
+        callers can fall back to the legacy country scan.
+        """
+        player_id = self.get_player_empire_id()
+        country = self._get_player_country_entry(player_id)
+        if isinstance(country, dict):
+            owned = country.get("owned_leaders")
+            if isinstance(owned, list):
+                return {str(x) for x in owned}
+        return None
+
     def _get_owned_fleet_ids_from_entry(self, country_entry: dict) -> list[str]:
         """Extract owned fleet IDs from a parsed country dict.
 

--- a/stellaris_save_extractor/diplomacy.py
+++ b/stellaris_save_extractor/diplomacy.py
@@ -9,6 +9,34 @@ from stellaris_companion.rust_bridge import ParserError, _get_active_session
 
 logger = logging.getLogger(__name__)
 
+# Country types that count as diplomatic "empires" for the known-empires tally.
+# Everything else in a relations_manager (enclaves, marauders, drones/space fauna,
+# pre-FTL primitives, internal event factions) is a relation record but not an
+# empire you've made contact with.
+DIPLOMATIC_EMPIRE_TYPES = frozenset({"default", "fallen_empire", "awakened_fallen_empire"})
+
+
+def _is_diplomatic_empire(country_type) -> bool:
+    """True if a target country type counts as a known empire (not a special entity)."""
+    return country_type in DIPLOMATIC_EMPIRE_TYPES
+
+
+def _summarize_relation_types(relations: list[dict]) -> dict:
+    """Count relations by target country type and how many are real empires.
+
+    Returns ``{"empire_count": int, "by_type": {type: count}}``. ``empire_count`` is
+    the count the in-game contacts list roughly reflects; ``relation_count`` (kept
+    separately) remains the raw total including special entities.
+    """
+    by_type: dict[str, int] = {}
+    empire_count = 0
+    for rel in relations:
+        ctype = rel.get("country_type") or "unknown"
+        by_type[ctype] = by_type.get(ctype, 0) + 1
+        if _is_diplomatic_empire(rel.get("country_type")):
+            empire_count += 1
+    return {"empire_count": empire_count, "by_type": by_type}
+
 
 def _format_resolution_name(type_key: str) -> str:
     """Convert a resolution type key to a human-readable name.
@@ -237,6 +265,14 @@ class DiplomacyMixin:
                 target_country_id, f"Empire {target_country_id}"
             )
 
+            # Record the target's country type so callers can distinguish real
+            # empires from special entities (enclaves, marauders, primitives, etc.).
+            target_country = self._get_countries_cached().get(str(target_country_id))
+            if isinstance(target_country, dict):
+                ctype = target_country.get("type")
+                if ctype:
+                    relation_info["country_type"] = ctype
+
             # Add authority and megacorp detection
             authority = country_authorities.get(target_country_id)
             if authority:
@@ -372,6 +408,12 @@ class DiplomacyMixin:
         result["sensor_links"] = sensor_links
         result["treaties"] = treaties
         result["relation_count"] = len(relations_found)
+        # Segment relations by target type: empire_count reflects actual known
+        # empires (what the in-game contacts list roughly shows), while
+        # relation_count stays the raw total including enclaves/marauders/etc.
+        type_summary = _summarize_relation_types(relations_found)
+        result["empire_count"] = type_summary["empire_count"]
+        result["relations_by_type"] = type_summary["by_type"]
         result["federation"] = federation_id
 
         # Summarize by opinion

--- a/stellaris_save_extractor/leaders.py
+++ b/stellaris_save_extractor/leaders.py
@@ -52,6 +52,12 @@ class LeadersMixin:
         player_id = self.get_player_empire_id()
         class_counts = {}
 
+        # Authoritative hired-leader roster. In 4.x the leaders section also holds
+        # unrecruited recruitment-pool candidates tagged with the player's country,
+        # so we filter to owned_leaders (matches the in-game Leaders screen). Falls
+        # back to the legacy country scan when the field is absent (older saves).
+        owned_leader_ids = self._get_player_owned_leader_ids()
+
         # Phase 1: Iterate and collect player leader data
         # (can't call get_duplicate_values during iter_section - same pipe)
         player_leaders_data = []
@@ -61,9 +67,13 @@ class LeadersMixin:
                 continue
 
             # Check if this leader belongs to the player
-            country_id = leader_data.get("country")
-            if country_id is None or int(country_id) != player_id:
-                continue
+            if owned_leader_ids is not None:
+                if str(leader_id) not in owned_leader_ids:
+                    continue
+            else:
+                country_id = leader_data.get("country")
+                if country_id is None or int(country_id) != player_id:
+                    continue
 
             # P011: Extract class using .get() with defaults
             leader_class = leader_data.get("class")

--- a/stellaris_save_extractor/leaders.py
+++ b/stellaris_save_extractor/leaders.py
@@ -10,6 +10,19 @@ from stellaris_companion.rust_bridge import (
 
 logger = logging.getLogger(__name__)
 
+# Envoys are stored as leaders in the save, but the game shows them in the
+# diplomacy panel (assigned to the galactic community, federations, spy networks,
+# improving/harming relations) — NOT in the Leaders screen. So the leader roster
+# count excludes them and they are reported separately.
+ENVOY_CLASS = "envoy"
+
+
+def _partition_envoys(leaders: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Split a leader list into (roster, envoys) by class."""
+    roster = [leader for leader in leaders if leader.get("class") != ENVOY_CLASS]
+    envoys = [leader for leader in leaders if leader.get("class") == ENVOY_CLASS]
+    return roster, envoys
+
 
 class LeadersMixin:
     """Domain methods extracted from the original SaveExtractor."""
@@ -160,8 +173,13 @@ class LeadersMixin:
         # Sort by leader ID to ensure consistent ordering
         leaders_found.sort(key=lambda x: int(x["id"]))
 
-        result["leaders"] = leaders_found
-        result["count"] = len(leaders_found)
+        # Envoys are diplomatic units shown separately from the Leaders screen, so
+        # the roster count excludes them (matches the in-game count).
+        roster, envoys = _partition_envoys(leaders_found)
+        result["leaders"] = roster
+        result["envoys"] = envoys
+        result["count"] = len(roster)
+        result["envoy_count"] = len(envoys)
         result["by_class"] = class_counts
 
         return result

--- a/tests/test_diplomacy_empire_count.py
+++ b/tests/test_diplomacy_empire_count.py
@@ -1,0 +1,52 @@
+"""Tests for diplomacy 'known empires' counting (Stellaris 4.x).
+
+The player's relations_manager holds a relation record for every country it knows
+about — including non-empire entities (enclaves, marauders, drones, primitives,
+internal factions). Counting all relations over-states "known empires" (e.g. 13
+records vs 8 actual empires). We segment by the target country's `type`.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from stellaris_save_extractor.diplomacy import (
+    _is_diplomatic_empire,
+    _summarize_relation_types,
+)
+
+
+def test_is_diplomatic_empire_recognizes_empire_types():
+    assert _is_diplomatic_empire("default")
+    assert _is_diplomatic_empire("fallen_empire")
+    assert _is_diplomatic_empire("awakened_fallen_empire")
+
+
+def test_is_diplomatic_empire_rejects_special_entities():
+    for t in ("enclave", "dormant_marauders", "drone", "primitive", "nice_faction", None):
+        assert not _is_diplomatic_empire(t)
+
+
+def test_summarize_relation_types_counts_empires_and_breakdown():
+    relations = [
+        {"country_type": "default"},
+        {"country_type": "default"},
+        {"country_type": "fallen_empire"},
+        {"country_type": "enclave"},
+        {"country_type": "dormant_marauders"},
+        {"country_type": "primitive"},
+    ]
+
+    summary = _summarize_relation_types(relations)
+
+    assert summary["empire_count"] == 3
+    assert summary["by_type"]["default"] == 2
+    assert summary["by_type"]["enclave"] == 1
+    assert summary["by_type"]["primitive"] == 1
+
+
+def test_summarize_handles_missing_type_as_unknown():
+    summary = _summarize_relation_types([{"country_type": None}, {}])
+    assert summary["empire_count"] == 0
+    assert summary["by_type"]["unknown"] == 2

--- a/tests/test_leader_ownership.py
+++ b/tests/test_leader_ownership.py
@@ -12,6 +12,25 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from stellaris_save_extractor.base import SaveExtractorBase
+from stellaris_save_extractor.leaders import _partition_envoys
+
+
+def test_partition_envoys_splits_roster_from_envoys():
+    # Envoys are leaders in the save but appear in the diplomacy panel, not the
+    # Leaders screen, so the roster count must exclude them.
+    leaders = [
+        {"class": "commander"},
+        {"class": "envoy"},
+        {"class": "scientist"},
+        {"class": "envoy"},
+        {"class": "official"},
+    ]
+
+    roster, envoys = _partition_envoys(leaders)
+
+    assert len(roster) == 3
+    assert len(envoys) == 2
+    assert all(leader["class"] != "envoy" for leader in roster)
 
 
 class _Dummy(SaveExtractorBase):

--- a/tests/test_leader_ownership.py
+++ b/tests/test_leader_ownership.py
@@ -1,0 +1,48 @@
+"""Tests for player owned-leader selection (Stellaris 4.x leader counting).
+
+In Stellaris 4.x the ``leaders`` section contains both the empire's hired leaders
+AND unrecruited recruitment-pool candidates, all tagged with ``country=<player>``.
+Scanning by country therefore over-counts (e.g. 18 vs the 9 the Leaders screen
+shows). The authoritative hired-leader set is the country's ``owned_leaders`` list.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from stellaris_save_extractor.base import SaveExtractorBase
+
+
+class _Dummy(SaveExtractorBase):
+    """Minimal base double: stubs the two dependencies of _get_player_owned_leader_ids."""
+
+    def __init__(self, country_entry):
+        self._country_entry = country_entry
+
+    def get_player_empire_id(self):
+        return 1
+
+    def _get_player_country_entry(self, player_id=0):
+        return self._country_entry
+
+
+def test_returns_owned_leaders_as_string_set():
+    ext = _Dummy({"owned_leaders": ["158", "439", "16777810"]})
+    assert ext._get_player_owned_leader_ids() == {"158", "439", "16777810"}
+
+
+def test_coerces_ids_to_strings():
+    ext = _Dummy({"owned_leaders": [158, 439]})
+    assert ext._get_player_owned_leader_ids() == {"158", "439"}
+
+
+def test_returns_none_when_no_owned_leaders_field():
+    # Pre-4.x saves / missing field -> None so the caller falls back to the scan.
+    ext = _Dummy({})
+    assert ext._get_player_owned_leader_ids() is None
+
+
+def test_returns_none_when_country_entry_missing():
+    ext = _Dummy(None)
+    assert ext._get_player_owned_leader_ids() is None


### PR DESCRIPTION
## Description

Three Stellaris 4.x ("Pegasus") extraction fixes in the same family as the data-model issues tracked in #32 — found by cross-checking a real save against the in-game panels, and all confirmed against the live game.

### 1. Leader count (`get_leaders`)
Two problems made the leader count too high:
- It collected every `leaders` entry with `country == player_id`, which in 4.x also includes **unrecruited recruitment-pool candidates** (real leaders have a recruitment date + experience; pool candidates have `recruitment_date = "0.01.01"` and no XP).
- It counted **envoys**, which the game shows in the diplomacy panel (galactic community, federations, spy networks, relation missions), **not** the Leaders screen.

Fixes:
- Filter to the country's `owned_leaders` list (authoritative hired roster) via a new `base._get_player_owned_leader_ids()`, falling back to the legacy scan when absent.
- Partition the roster from envoys: `count` is now the Leaders-screen roster (commanders + scientists + officials), with `envoys` / `envoy_count` reported separately and `by_class` still listing every class.

**Result** on a real save: **19 → 10** (2 officials + 3 commanders + 5 scientists), exactly matching the in-game Leaders screen; the removed entries were the recruitment pool and 2 envoys.

### 2. Known-empire count (`get_diplomacy`)
`relation_count` counted every record in the player's `relations_manager`, but that includes **non-empire entities**: enclaves, marauders, pre-FTL primitives, space fauna (tiyanki/crystal/amoeba), and internal event factions.

Fix: record each relation's target `country_type` and add `empire_count` (real empires: default / fallen / awakened) plus a `relations_by_type` breakdown. `relation_count` is unchanged (raw total, backward compatible).

**Result:** `relation_count = 13`, of which only the real empires are counted by `empire_count` — which matches the in-game Contacts screen when its "Other" category (marauders/enclaves/fauna/factions) is filtered out.

## Related issue
Related to #32 (4.x extraction-compatibility audit). New instances of the failure modes catalogued there.

## Priority alignment
- [x] This PR aligns with current priorities: DLC coverage/correctness, Windows/Linux reliability, or stability of existing features
- [ ] If this is a new feature, I explained why it is critical right now

Correctness fixes for 4.x save extraction; no new features.

## DLC impact
- [x] No DLC behavior changed
- [ ] DLC behavior changed; affected DLC(s) are listed in the PR description

Base-game 4.x gamestate shapes (leaders, relations_manager); no DLC-specific behavior.

## Platform validation
- [x] I tested on Windows and/or Linux, or explained why that was not possible

Developed and verified on Windows 11 (Python 3.12): full test suite, real-save extraction, and in-game panel confirmation.

## Regression risk
Both changes preserve prior behavior where the new data is unavailable: leaders falls back to the country scan when `owned_leaders` is absent, and diplomacy leaves `relation_count` and all existing fields unchanged (only adds `empire_count` / `relations_by_type` / per-relation `country_type`, and `envoys`/`envoy_count`). New logic is covered by unit tests and real-save verification.

## Testing status
**Verified:**
- `pytest tests/` — 224 passed, 20 skipped (+9 new tests)
- Real 4.x save: `get_leaders().count` now matches the in-game Leaders screen (10 = 2 officials + 3 commanders + 5 scientists), envoys reported separately.
- `get_diplomacy().empire_count` matches the in-game Contacts screen with the "Other" category filtered out.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation

## Checklist
- [x] Tests pass locally (`pytest tests/`) — 224 passed, 20 skipped
- [x] Rust parser builds (`cd stellaris-parser && cargo build --release`) — no Rust changes; builds clean
- [x] No new warnings — the single pytest warning is a pre-existing Starlette deprecation
- [x] I have tested with a real Stellaris save file — extraction verified against real MP saves and confirmed against the in-game Leaders and Contacts screens