### PR TITLE
feat: add beta update channel for 0.8.5

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -22,8 +22,34 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
+      channel: ${{ steps.release-metadata.outputs.channel }}
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      prerelease: ${{ steps.release-metadata.outputs.prerelease }}
+      publish: ${{ steps.release-metadata.outputs.publish }}
+      tag: ${{ steps.release-metadata.outputs.tag }}
+      version: ${{ steps.release-metadata.outputs.version }}
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Validate release metadata
+        id: release-metadata
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./electron/package.json').version")
+          if [ "${{ github.event_name }}" = "push" ]; then
+            node scripts/classify_release.js \
+              --version "$VERSION" \
+              --tag "${{ github.ref_name }}" \
+              --output "$GITHUB_OUTPUT"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            node scripts/classify_release.js \
+              --version "$VERSION" \
+              --output "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: set-matrix
         shell: bash
         run: |
@@ -38,7 +64,7 @@ jobs:
 
   release:
     needs: setup
-    name: Release - ${{ matrix.name }}
+    name: Build - ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -51,12 +77,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      # --- Rust Parser Build ---
       - name: Build Rust Parser
-        run: |
-          cd stellaris-parser
-          cargo build --release
-          cd ..
+        run: cargo build --release
+        working-directory: stellaris-parser
 
       - name: Prepare Rust Binary
         shell: bash
@@ -72,14 +95,10 @@ jobs:
             cp stellaris-parser/target/release/stellaris-parser bin/stellaris-parser-darwin-x64
           elif [[ "${{ matrix.name }}" == "linux-x64" ]]; then
             cp stellaris-parser/target/release/stellaris-parser bin/stellaris-parser-linux-x64
-          else
-            cp stellaris-parser/target/release/stellaris-parser bin/stellaris-parser
           fi
 
-          echo "Binaries in bin/:"
           ls -la bin/
 
-      # --- Python Backend Build ---
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -110,7 +129,6 @@ jobs:
           chmod +x scripts/build-python.sh
           ./scripts/build-python.sh
 
-      # --- Electron Build & Publish ---
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -119,6 +137,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install Node Dependencies
+        shell: bash
         run: |
           cd electron
           npm ci
@@ -136,10 +155,9 @@ jobs:
         working-directory: electron
         run: npm run build:mcpb
 
-      - name: CI smoke check (inputs for packaging)
+      - name: CI smoke check
         shell: bash
-        run: |
-          bash scripts/ci-smoke-check.sh "${{ matrix.name }}"
+        run: bash scripts/ci-smoke-check.sh "${{ matrix.name }}"
 
       - name: Import code signing certificate
         if: startsWith(matrix.name, 'mac')
@@ -159,40 +177,50 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security import "$CERT_FILE" -P "$CSC_KEY_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
-
-          echo "Imported cert into keychain. Available identities:"
+          EXISTING_KEYCHAINS=()
+          while IFS= read -r keychain; do
+            EXISTING_KEYCHAINS+=("${keychain//\"/}")
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "${EXISTING_KEYCHAINS[@]}"
           security find-identity -v -p codesigning
-
           rm -f "$CERT_FILE"
 
-      - name: Publish Electron App (mac)
-        if: startsWith(matrix.name, 'mac')
+      - name: Build or publish Electron App
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          cd electron
-          npx electron-builder ${{ matrix.electron_args }} --publish always
+          CSC_LINK: ${{ startsWith(matrix.name, 'mac') && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ startsWith(matrix.name, 'mac') && secrets.CSC_KEY_PASSWORD || '' }}
+          APPLE_ID: ${{ startsWith(matrix.name, 'mac') && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ startsWith(matrix.name, 'mac') && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ startsWith(matrix.name, 'mac') && secrets.APPLE_TEAM_ID || '' }}
+          PUBLISH_MODE: ${{ needs.setup.outputs.publish == 'true' && 'always' || 'never' }}
+          RELEASE_CHANNEL: ${{ needs.setup.outputs.channel }}
+        working-directory: electron
+        run: npx electron-builder ${{ matrix.electron_args }} --publish "$PUBLISH_MODE" --config.publish.channel="$RELEASE_CHANNEL"
 
-      - name: Publish Electron App (non-mac)
-        if: ${{ !startsWith(matrix.name, 'mac') }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd electron
-          npx electron-builder ${{ matrix.electron_args }} --publish always
-
-      - name: Publish Claude Desktop MCPB
-        if: ${{ matrix.name == 'linux-x64' && startsWith(github.ref, 'refs/tags/') }}
+      - name: Upload Claude Desktop MCPB to draft release
+        if: ${{ matrix.name == 'linux-x64' && needs.setup.outputs.publish == 'true' }}
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.setup.outputs.tag }}
           files: electron/dist/mcpb/*.mcpb
           fail_on_unmatched_files: true
+          draft: true
+
+      - name: Upload manual build artifacts
+        if: ${{ needs.setup.outputs.publish != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: stellaris-companion-${{ needs.setup.outputs.version }}-${{ matrix.name }}
+          path: |
+            electron/dist/*.AppImage
+            electron/dist/*.blockmap
+            electron/dist/*.dmg
+            electron/dist/*.exe
+            electron/dist/*.yml
+            electron/dist/*.zip
+            electron/dist/mcpb/*.mcpb
+          if-no-files-found: error
 
       - name: Fetch notarization log on failure
         if: failure() && startsWith(matrix.name, 'mac')
@@ -202,15 +230,12 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         shell: bash
         run: |
-          echo "=== Fetching notarization history ==="
           xcrun notarytool history \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
             2>&1 | head -20
 
-          echo ""
-          echo "=== Fetching log for most recent submission ==="
           SUBMISSION_ID=$(xcrun notarytool history \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
@@ -218,18 +243,110 @@ jobs:
             2>&1 | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
 
           if [ -n "$SUBMISSION_ID" ]; then
-            echo "Submission ID: $SUBMISSION_ID"
             xcrun notarytool log "$SUBMISSION_ID" \
               --apple-id "$APPLE_ID" \
               --password "$APPLE_APP_SPECIFIC_PASSWORD" \
               --team-id "$APPLE_TEAM_ID" \
               2>&1
-          else
-            echo "Could not find submission ID"
           fi
 
+  finalize_release:
+    needs: [setup, release]
+    if: needs.setup.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ needs.setup.outputs.tag }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Download both macOS update archives
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.setup.outputs.tag }}
+          VERSION: ${{ needs.setup.outputs.version }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/update-feed
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "Stellaris-Companion-${VERSION}-arm64-mac.zip" \
+            --dir /tmp/update-feed
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "Stellaris-Companion-${VERSION}-mac.zip" \
+            --dir /tmp/update-feed
+
+      - name: Generate architecture-complete macOS update feed
+        env:
+          CHANNEL: ${{ needs.setup.outputs.channel }}
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: |
+          node scripts/finalize_mac_update_manifest.js \
+            --version "$VERSION" \
+            --assets-dir /tmp/update-feed \
+            --notes electron/release-notes.md \
+            --output "/tmp/update-feed/${CHANNEL}-mac.yml"
+
+      - name: Prepare Stable aliases for Beta subscribers
+        if: needs.setup.outputs.prerelease != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        shell: bash
+        run: |
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "latest.yml" \
+            --pattern "latest-linux.yml" \
+            --dir /tmp/update-feed
+          cp /tmp/update-feed/latest.yml /tmp/update-feed/beta.yml
+          cp /tmp/update-feed/latest-linux.yml /tmp/update-feed/beta-linux.yml
+          cp /tmp/update-feed/latest-mac.yml /tmp/update-feed/beta-mac.yml
+
+      - name: Upload finalized update feeds
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        shell: bash
+        run: |
+          gh release upload "$TAG" /tmp/update-feed/*.yml \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+      - name: Publish Stable release
+        if: needs.setup.outputs.prerelease != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        shell: bash
+        run: |
+          gh release edit "$TAG" \
+            --repo "${{ github.repository }}" \
+            --draft=false \
+            --prerelease=false \
+            --latest \
+            --notes-file electron/release-notes.md
+
+      - name: Publish Beta release
+        if: needs.setup.outputs.prerelease == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.setup.outputs.tag }}
+        shell: bash
+        run: |
+          gh release edit "$TAG" \
+            --repo "${{ github.repository }}" \
+            --draft=false \
+            --prerelease \
+            --latest=false \
+            --notes-file electron/release-notes.md
+
   deploy-promo-site:
-    needs: release
+    needs: [setup, finalize_release]
+    if: needs.setup.outputs.prerelease != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v4
@@ -239,11 +356,12 @@ jobs:
       - name: Synchronize promo site release facts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.finalize_release.outputs.tag }}
         run: |
           git clone --depth 1 https://x-access-token:${{ secrets.PROMO_SITE_TOKEN }}@github.com/gitmaan/stellaris-companion-site.git /tmp/site
           cd /tmp/site
           npm ci
-          npm run release:sync -- --tag "${{ github.ref_name }}"
+          npm run release:sync -- --tag "$RELEASE_TAG"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add \
@@ -251,8 +369,8 @@ jobs:
             public/.well-known/product-facts.json \
             public/.well-known/agent-skills/index.json
           if git diff --cached --quiet; then
-            git commit --allow-empty -m "chore: rebuild for ${{ github.ref_name }}"
+            git commit --allow-empty -m "chore: rebuild for $RELEASE_TAG"
           else
-            git commit -m "chore: sync release facts for ${{ github.ref_name }}"
+            git commit -m "chore: sync release facts for $RELEASE_TAG"
           fi
           git push

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -185,15 +185,26 @@ jobs:
           security find-identity -v -p codesigning
           rm -f "$CERT_FILE"
 
-      - name: Build or publish Electron App
+      - name: Build or publish Electron App (macOS)
+        if: startsWith(matrix.name, 'mac')
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ startsWith(matrix.name, 'mac') && secrets.CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ startsWith(matrix.name, 'mac') && secrets.CSC_KEY_PASSWORD || '' }}
-          APPLE_ID: ${{ startsWith(matrix.name, 'mac') && secrets.APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ startsWith(matrix.name, 'mac') && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ startsWith(matrix.name, 'mac') && secrets.APPLE_TEAM_ID || '' }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PUBLISH_MODE: ${{ needs.setup.outputs.publish == 'true' && 'always' || 'never' }}
+          RELEASE_CHANNEL: ${{ needs.setup.outputs.channel }}
+        working-directory: electron
+        run: npx electron-builder ${{ matrix.electron_args }} --publish "$PUBLISH_MODE" --config.publish.channel="$RELEASE_CHANNEL"
+
+      - name: Build or publish Electron App
+        if: ${{ !startsWith(matrix.name, 'mac') }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_MODE: ${{ needs.setup.outputs.publish == 'true' && 'always' || 'never' }}
           RELEASE_CHANNEL: ${{ needs.setup.outputs.channel }}
         working-directory: electron

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -186,6 +186,7 @@ jobs:
           rm -f "$CERT_FILE"
 
       - name: Build or publish Electron App
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ startsWith(matrix.name, 'mac') && secrets.CSC_LINK || '' }}

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,4 +5,4 @@ Stellaris Companion Backend
 Electron app backend with Gemini-powered strategic advisor for Stellaris.
 """
 
-__version__ = "0.6.2"
+__version__ = "0.8.5"

--- a/docs/ipc-contract.md
+++ b/docs/ipc-contract.md
@@ -47,8 +47,12 @@ Example (backend):
 
 ```py
 raise HTTPException(
-  status_code=409,
-  detail={"error": "Chronicle generation already in progress", "code": "CHRONICLE_IN_PROGRESS", "retry_after_ms": 2000},
+    status_code=409,
+    detail={
+        "error": "Chronicle generation already in progress",
+        "code": "CHRONICLE_IN_PROGRESS",
+        "retry_after_ms": 2000,
+    },
 )
 ```
 
@@ -77,4 +81,3 @@ Only backend-proxy calls (`window.electronAPI.backend.*`) use the envelope.
 Other IPC surfaces (settings, updates, discord, announcements, onboarding) may return
 domain-specific shapes and/or send push events (`backend-status`, `update-*`,
 `discord-*`, `announcements-updated`).
-

--- a/electron/e2e/chronicle-publishing.spec.js
+++ b/electron/e2e/chronicle-publishing.spec.js
@@ -17,6 +17,7 @@ async function launchApp(backendPort, userDataDir) {
       E2E: '1',
       E2E_ONBOARDING_COMPLETE: '1',
       E2E_BACKEND_CONFIGURED: '1',
+      E2E_FAKE_SECURE_STORAGE: '1',
       E2E_SKIP_BACKEND_AUTOSTART: '1',
       E2E_USER_DATA_DIR: userDataDir,
       STELLARIS_API_PORT: String(backendPort),

--- a/electron/e2e/update-channel.spec.js
+++ b/electron/e2e/update-channel.spec.js
@@ -1,0 +1,53 @@
+const fs = require('fs/promises')
+const os = require('os')
+const path = require('path')
+
+const { test, expect, _electron: electron } = require('@playwright/test')
+
+const electronDir = path.resolve(__dirname, '..')
+
+function launchApp(userDataDir) {
+  return electron.launch({
+    args: [path.join(electronDir, 'main.js')],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      E2E: '1',
+      E2E_ONBOARDING_COMPLETE: '1',
+      E2E_BACKEND_CONFIGURED: '1',
+      E2E_SKIP_BACKEND_AUTOSTART: '1',
+      E2E_USER_DATA_DIR: userDataDir,
+    },
+  })
+}
+
+async function openUpdateSettings(app) {
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await page.getByRole('button', { name: 'Config' }).click()
+  const control = page.getByTestId('update-channel-control')
+  await control.scrollIntoViewIfNeeded()
+  return { page, control }
+}
+
+test('persists a Stable or Beta update preference across launches', async () => {
+  const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stellaris-companion-updates-e2e-'))
+  let app = await launchApp(userDataDir)
+
+  try {
+    let { control } = await openUpdateSettings(app)
+    await expect(control.getByRole('button', { name: /Stable/ })).toHaveAttribute('aria-pressed', 'true')
+    await control.getByRole('button', { name: /Beta/ }).click()
+    await expect(control.getByRole('button', { name: /Beta/ })).toHaveAttribute('aria-pressed', 'true')
+    await app.close()
+
+    app = await launchApp(userDataDir)
+    ;({ control } = await openUpdateSettings(app))
+    await expect(control.getByRole('button', { name: /Beta/ })).toHaveAttribute('aria-pressed', 'true')
+    await control.getByRole('button', { name: /Stable/ }).click()
+    await expect(control.getByRole('button', { name: /Stable/ })).toHaveAttribute('aria-pressed', 'true')
+  } finally {
+    await app.close()
+    await fs.rm(userDataDir, { recursive: true, force: true })
+  }
+})

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -76,7 +76,7 @@ publish:
   provider: github
   owner: gitmaan
   repo: stellaris-companion
-  releaseType: release
+  releaseType: draft
 
 releaseInfo:
   releaseNotesFile: release-notes.md

--- a/electron/main.js
+++ b/electron/main.js
@@ -21,6 +21,7 @@ const { autoUpdater } = require('electron-updater')
 const { createBackendClient } = require('./main/backendClient')
 const { createAnnouncementsService } = require('./main/announcements')
 const { createHealthCheckManager } = require('./main/healthcheck')
+const { getLinuxSaveDirCandidates } = require('./main/savePaths')
 const { createSecretStorage } = require('./main/secureStorage')
 const {
   applyUpdateChannel,
@@ -978,21 +979,7 @@ function getSaveDirCandidates() {
   const homedir = os.homedir()
   const candidates = []
   if (process.platform === 'linux') {
-    const localShare = path.join(homedir, '.local', 'share', 'Paradox Interactive')
-    const flatpakShare = path.join(
-      homedir,
-      '.var',
-      'app',
-      'com.valvesoftware.Steam',
-      '.local',
-      'share',
-      'Paradox Interactive',
-    )
-    candidates.push(
-      path.join(localShare, 'Stellaris', 'save games'),
-      path.join(localShare, 'Stellaris Plaza', 'save games'),
-      path.join(flatpakShare, 'Stellaris', 'save games'),
-    )
+    candidates.push(...getLinuxSaveDirCandidates(homedir))
   } else {
     let documentsPath
     try {

--- a/electron/main.js
+++ b/electron/main.js
@@ -21,7 +21,14 @@ const { autoUpdater } = require('electron-updater')
 const { createBackendClient } = require('./main/backendClient')
 const { createAnnouncementsService } = require('./main/announcements')
 const { createHealthCheckManager } = require('./main/healthcheck')
-const { setupAutoUpdater, registerUpdateIpcHandlers, wireAutoUpdaterEvents } = require('./main/updates')
+const { createSecretStorage } = require('./main/secureStorage')
+const {
+  applyUpdateChannel,
+  normalizeUpdateChannel,
+  registerUpdateIpcHandlers,
+  setupAutoUpdater,
+  wireAutoUpdaterEvents,
+} = require('./main/updates')
 const { registerBackendIpcHandlers } = require('./main/ipc/backend')
 const { registerSettingsIpcHandlers } = require('./main/ipc/settings')
 const { registerExportIpcHandlers } = require('./main/ipc/export')
@@ -62,9 +69,6 @@ if (E2E_USER_DATA_DIR) {
   }
 }
 
-// Configure electron-updater
-setupAutoUpdater({ autoUpdater, app, isDev: IS_DEV })
-
 // Global process error handlers (ELEC-xxx: diagnostics)
 // Prevent silent failures in production builds.
 let hasShownFatalErrorDialog = false
@@ -104,45 +108,14 @@ if (!IS_DEV && !IS_E2E) {
   }
 }
 
-// Secrets are encrypted via Electron's safeStorage API and persisted in
-// electron-store as base64 strings.  This replaces the deprecated keytar
-// native module and eliminates architecture-mismatch crashes.
+// Secrets use Electron safeStorage when the selected OS backend protects data
+// at rest. Environments without protected storage keep secrets in memory only.
 const SECRET_STORE_KEYS = {
   googleApiKey: 'secrets.google-api-key',
   discordToken: 'secrets.discord-token',
   discordAccessToken: 'secrets.discord-access-token',
   discordRefreshToken: 'secrets.discord-refresh-token',
   chroniclePublisherSecret: 'secrets.chronicle-publisher-secret',
-}
-
-function encryptSecret(plaintext) {
-  if (!plaintext) return null
-  if (!safeStorage.isEncryptionAvailable()) return Buffer.from(plaintext).toString('base64')
-  return safeStorage.encryptString(plaintext).toString('base64')
-}
-
-function decryptSecret(stored) {
-  if (!stored) return null
-  const buf = Buffer.from(stored, 'base64')
-  if (!safeStorage.isEncryptionAvailable()) return buf.toString('utf-8')
-  try {
-    return safeStorage.decryptString(buf)
-  } catch {
-    // Data was stored without encryption or is corrupt — treat as plaintext
-    return buf.toString('utf-8')
-  }
-}
-
-function getSecret(key) {
-  return decryptSecret(store.get(key))
-}
-
-function setSecret(key, value) {
-  if (value) {
-    store.set(key, encryptSecret(value))
-  } else {
-    store.delete(key)
-  }
 }
 
 // Initialize electron-store for non-secret settings
@@ -180,6 +153,10 @@ const store = new Store({
     announcementsLastRead: 0,
   },
 })
+
+const secretStorage = createSecretStorage({ safeStorage, store })
+const getSecret = key => secretStorage.getSecret(key)
+const setSecret = (key, value) => secretStorage.setSecret(key, value)
 
 const announcementsService = createAnnouncementsService({ app, store })
 
@@ -802,6 +779,17 @@ function getResolvedLanguageSetting() {
   return resolveLanguage(getLanguageSetting())
 }
 
+function getUpdateChannelSetting() {
+  return normalizeUpdateChannel(store.get('updateChannel'), app.getVersion())
+}
+
+setupAutoUpdater({
+  autoUpdater,
+  app,
+  isDev: IS_DEV,
+  updateChannel: getUpdateChannelSetting(),
+})
+
 function applyUiScaleToWindow(targetWindow = mainWindow) {
   if (!targetWindow || targetWindow.isDestroyed()) return
   targetWindow.webContents.setZoomFactor(getUiScaleSetting())
@@ -827,6 +815,7 @@ function stepUiScale(direction) {
 function getSettings() {
   const googleApiKey = getSecret(SECRET_STORE_KEYS.googleApiKey)
   const discordToken = getSecret(SECRET_STORE_KEYS.discordToken)
+  const secretStorageStatus = secretStorage.getStatus()
 
   const saveDir = store.get('saveDir', '')
   const playerName = store.get('playerName', '')
@@ -838,10 +827,13 @@ function getSettings() {
   const modelRoutingMode = getModelRoutingModeSetting()
   const language = getLanguageSetting()
   const resolvedLanguage = getResolvedLanguageSetting()
+  const updateChannel = getUpdateChannelSetting()
 
   return {
     googleApiKey: maskSecret(googleApiKey),
     googleApiKeySet: !!googleApiKey,
+    secretStorageAvailable: secretStorageStatus.persistentEncryptionAvailable,
+    secretStorageBackend: secretStorageStatus.backend,
     discordToken: maskSecret(discordToken),
     discordTokenSet: !!discordToken,
     saveDir,
@@ -856,6 +848,7 @@ function getSettings() {
     modelRoutingMode,
     language,
     resolvedLanguage,
+    updateChannel,
   }
 }
 
@@ -865,6 +858,12 @@ function getSettings() {
  */
 function getSettingsWithSecrets() {
   const googleApiKey = getSecret(SECRET_STORE_KEYS.googleApiKey) || ''
+  const secretStorageStatus = secretStorage.getStatus()
+  if (!secretStorageStatus.persistentEncryptionAvailable) {
+    // Remove any legacy publisher credential from unprotected disk storage,
+    // retaining it only for this process.
+    getSecret(SECRET_STORE_KEYS.chroniclePublisherSecret)
+  }
   const discordToken = getSecret(SECRET_STORE_KEYS.discordToken) || ''
   const saveDir = store.get('saveDir', '')
   const playerName = store.get('playerName', '')
@@ -877,6 +876,7 @@ function getSettingsWithSecrets() {
   const modelRoutingMode = getModelRoutingModeSetting()
   const language = getLanguageSetting()
   const resolvedLanguage = getResolvedLanguageSetting()
+  const updateChannel = getUpdateChannelSetting()
 
   return {
     googleApiKey,
@@ -894,6 +894,7 @@ function getSettingsWithSecrets() {
     modelRoutingMode,
     language,
     resolvedLanguage,
+    updateChannel,
   }
 }
 
@@ -953,6 +954,18 @@ function saveSettings(settings) {
 
   if (settings.language !== undefined) {
     store.set('language', normalizeLanguage(settings.language))
+  }
+
+  if (settings.updateChannel !== undefined) {
+    const updateChannel = normalizeUpdateChannel(settings.updateChannel, app.getVersion())
+    store.set('updateChannel', updateChannel)
+    applyUpdateChannel({
+      autoUpdater,
+      app,
+      isDev: IS_DEV,
+      updateChannel,
+      checkNow: true,
+    })
   }
 
   return { success: true }
@@ -1510,7 +1523,9 @@ const chroniclePublishingService = createChroniclePublishingService({
   getSecret,
   setSecret,
   secretStoreKey: SECRET_STORE_KEYS.chroniclePublisherSecret,
-  isEncryptionAvailable: () => safeStorage.isEncryptionAvailable(),
+  // Headless Linux CI has no OS keyring; E2E data is isolated in a temporary profile.
+  isEncryptionAvailable: () => secretStorage.getStatus().persistentEncryptionAvailable
+    || (IS_E2E && process.env.E2E_FAKE_SECURE_STORAGE === '1'),
 })
 
 registerChroniclePublishingIpcHandlers({
@@ -1547,7 +1562,7 @@ registerUpdateIpcHandlers({
     healthCheckManager.setIsQuitting(true)
   },
 })
-wireAutoUpdaterEvents({ autoUpdater, getMainWindow: () => mainWindow })
+wireAutoUpdaterEvents({ autoUpdater, app, getMainWindow: () => mainWindow })
 
 // =============================================================================
 // Onboarding IPC Handlers

--- a/electron/main/savePaths.js
+++ b/electron/main/savePaths.js
@@ -1,0 +1,34 @@
+const path = require('path')
+
+const STELLARIS_STEAM_APP_ID = '281990'
+const PROTON_SAVE_SEGMENTS = [
+  'steamapps',
+  'compatdata',
+  STELLARIS_STEAM_APP_ID,
+  'pfx',
+  'drive_c',
+  'users',
+  'steamuser',
+  'Documents',
+  'Paradox Interactive',
+  'Stellaris',
+  'save games',
+]
+
+function getLinuxSaveDirCandidates(homedir) {
+  const nativeShare = path.join(homedir, '.local', 'share', 'Paradox Interactive')
+  const flatpakRoot = path.join(homedir, '.var', 'app', 'com.valvesoftware.Steam')
+
+  return [
+    path.join(nativeShare, 'Stellaris', 'save games'),
+    path.join(nativeShare, 'Stellaris Plaza', 'save games'),
+    path.join(flatpakRoot, '.local', 'share', 'Paradox Interactive', 'Stellaris', 'save games'),
+    path.join(homedir, '.steam', 'steam', ...PROTON_SAVE_SEGMENTS),
+    path.join(homedir, '.local', 'share', 'Steam', ...PROTON_SAVE_SEGMENTS),
+    path.join(flatpakRoot, 'data', 'Steam', ...PROTON_SAVE_SEGMENTS),
+  ]
+}
+
+module.exports = {
+  getLinuxSaveDirCandidates,
+}

--- a/electron/main/secureStorage.js
+++ b/electron/main/secureStorage.js
@@ -1,0 +1,110 @@
+function getSecretStorageStatus(safeStorage, platform = process.platform) {
+  let encryptionAvailable = false
+  try {
+    encryptionAvailable = Boolean(safeStorage?.isEncryptionAvailable?.())
+  } catch {
+    encryptionAvailable = false
+  }
+
+  let backend = null
+  if (platform === 'linux' && typeof safeStorage?.getSelectedStorageBackend === 'function') {
+    try {
+      backend = safeStorage.getSelectedStorageBackend()
+    } catch {
+      backend = null
+    }
+  }
+
+  const linuxBackendIsProtected = platform !== 'linux'
+    || Boolean(backend && !['basic_text', 'unknown'].includes(backend))
+
+  return {
+    backend,
+    encryptionAvailable,
+    persistentEncryptionAvailable: encryptionAvailable && linuxBackendIsProtected,
+  }
+}
+
+function createSecretStorage({
+  safeStorage,
+  store,
+  platform = process.platform,
+}) {
+  const sessionSecrets = new Map()
+  let persistenceFailed = false
+
+  function getStatus() {
+    const status = getSecretStorageStatus(safeStorage, platform)
+    return persistenceFailed
+      ? { ...status, persistentEncryptionAvailable: false }
+      : status
+  }
+
+  function decryptStoredSecret(stored) {
+    if (!stored) return null
+    const buffer = Buffer.from(stored, 'base64')
+    const status = getStatus()
+    if (status.encryptionAvailable) {
+      try {
+        return { value: safeStorage.decryptString(buffer), legacyPlaintext: false }
+      } catch {
+        // Older builds stored base64 plaintext when safeStorage was unavailable.
+      }
+    }
+    return { value: buffer.toString('utf8'), legacyPlaintext: true }
+  }
+
+  function getSecret(key) {
+    if (sessionSecrets.has(key)) return sessionSecrets.get(key)
+
+    const stored = store.get(key)
+    if (!stored) return null
+
+    const { value, legacyPlaintext } = decryptStoredSecret(stored)
+    const status = getStatus()
+    if (!status.persistentEncryptionAvailable) {
+      if (value) sessionSecrets.set(key, value)
+      store.delete(key)
+    } else if (legacyPlaintext && value) {
+      setSecret(key, value)
+    }
+    return value
+  }
+
+  function setSecret(key, value) {
+    if (!value) {
+      sessionSecrets.delete(key)
+      store.delete(key)
+      return { persisted: false }
+    }
+
+    if (!getStatus().persistentEncryptionAvailable) {
+      sessionSecrets.set(key, value)
+      store.delete(key)
+      return { persisted: false }
+    }
+
+    try {
+      const encrypted = safeStorage.encryptString(value).toString('base64')
+      store.set(key, encrypted)
+      sessionSecrets.delete(key)
+      return { persisted: true }
+    } catch {
+      persistenceFailed = true
+      sessionSecrets.set(key, value)
+      store.delete(key)
+      return { persisted: false }
+    }
+  }
+
+  return {
+    getSecret,
+    getStatus,
+    setSecret,
+  }
+}
+
+module.exports = {
+  createSecretStorage,
+  getSecretStorageStatus,
+}

--- a/electron/main/updates.js
+++ b/electron/main/updates.js
@@ -1,16 +1,102 @@
+const semver = require('semver')
+
 const IS_E2E = process.env.E2E === '1'
+const UPDATE_CHANNELS = ['stable', 'beta']
+const DEFAULT_UPDATE_CHANNEL = 'stable'
 
-function setupAutoUpdater({ autoUpdater, app, isDev }) {
-  if (IS_E2E) return
-  if (isDev) return
-  if (!app?.isPackaged) return
-  if (process.windowsStore) return
+const updaterState = {
+  updateChannel: DEFAULT_UPDATE_CHANNEL,
+  availableVersion: null,
+  downloadedVersion: null,
+  releaseName: null,
+  releaseNotes: null,
+  installing: false,
+  installTimeout: null,
+}
 
-  // On macOS, running directly from a mounted .dmg (e.g. /Volumes/...) can cause
-  // updater errors. Only auto-check once installed.
-  if (process.platform === 'darwin' && process.execPath.includes('/Volumes/')) {
-    return
+function inferUpdateChannelFromVersion(version) {
+  const prerelease = semver.prerelease(version)
+  return prerelease?.[0] === 'beta' ? 'beta' : DEFAULT_UPDATE_CHANNEL
+}
+
+function normalizeUpdateChannel(value, appVersion = '') {
+  return UPDATE_CHANNELS.includes(value)
+    ? value
+    : inferUpdateChannelFromVersion(appVersion)
+}
+
+function getFeedChannel(updateChannel) {
+  return updateChannel === 'beta' ? 'beta' : 'latest'
+}
+
+function resetCachedUpdate() {
+  updaterState.availableVersion = null
+  updaterState.downloadedVersion = null
+  updaterState.releaseName = null
+  updaterState.releaseNotes = null
+  updaterState.installing = false
+  if (updaterState.installTimeout) {
+    clearTimeout(updaterState.installTimeout)
+    updaterState.installTimeout = null
   }
+}
+
+function configureUpdateChannel({ autoUpdater, updateChannel, appVersion = '' }) {
+  const normalized = normalizeUpdateChannel(updateChannel, appVersion)
+  autoUpdater.channel = getFeedChannel(normalized)
+  autoUpdater.allowPrerelease = normalized === 'beta'
+  // Setting electron-updater's channel can enable downgrades. Never replace a
+  // newer beta with an older stable build; Stable resumes at the next upgrade.
+  autoUpdater.allowDowngrade = false
+  resetCachedUpdate()
+  updaterState.updateChannel = normalized
+  return normalized
+}
+
+function canUseAutoUpdater({
+  app,
+  isDev,
+  isE2E = IS_E2E,
+  platform = process.platform,
+  execPath = process.execPath,
+  windowsStore = process.windowsStore,
+}) {
+  if (isE2E || isDev || !app?.isPackaged || windowsStore) return false
+  return !(platform === 'darwin' && execPath.includes('/Volumes/'))
+}
+
+function checkForUpdatesSafely(autoUpdater, source) {
+  try {
+    const request = autoUpdater.checkForUpdates()
+    if (request && typeof request.catch === 'function') {
+      request.catch((error) => console.error(`Auto-updater error (${source}):`, error))
+    }
+  } catch (error) {
+    console.error(`Auto-updater error (${source}):`, error)
+  }
+}
+
+function applyUpdateChannel({
+  autoUpdater,
+  app,
+  isDev,
+  updateChannel,
+  checkNow = false,
+}) {
+  const normalized = configureUpdateChannel({
+    autoUpdater,
+    updateChannel,
+    appVersion: app?.getVersion?.() || '',
+  })
+  if (checkNow && canUseAutoUpdater({ app, isDev })) {
+    checkForUpdatesSafely(autoUpdater, 'channel change')
+  }
+  return normalized
+}
+
+function setupAutoUpdater({ autoUpdater, app, isDev, updateChannel }) {
+  applyUpdateChannel({ autoUpdater, app, isDev, updateChannel })
+  if (!canUseAutoUpdater({ app, isDev })) return null
 
   // We use a custom in-app updater UX, so avoid native notifications.
   autoUpdater.autoDownload = true
@@ -21,35 +107,13 @@ function setupAutoUpdater({ autoUpdater, app, isDev }) {
     autoUpdater.autoInstallOnAppQuit = false
   }
 
-  // Avoid startup crashes on platforms/configs where update checks can throw
-  // synchronously or reject promises (network, feed parsing, etc).
-  try {
-    const p = autoUpdater.checkForUpdates()
-    if (p && typeof p.catch === 'function') {
-      p.catch((err) => console.error('Auto-updater error (startup):', err))
-    }
-  } catch (err) {
-    console.error('Auto-updater error (startup):', err)
-  }
-
-  setInterval(() => {
-    try {
-      const p = autoUpdater.checkForUpdates()
-      if (p && typeof p.catch === 'function') {
-        p.catch((err) => console.error('Auto-updater error (interval):', err))
-      }
-    } catch (err) {
-      console.error('Auto-updater error (interval):', err)
-    }
-  }, 3600000)
-}
-
-const updaterState = {
-  downloadedVersion: null,
-  releaseName: null,
-  releaseNotes: null,
-  installing: false,
-  installTimeout: null,
+  checkForUpdatesSafely(autoUpdater, 'startup')
+  const interval = setInterval(
+    () => checkForUpdatesSafely(autoUpdater, 'interval'),
+    3600000,
+  )
+  interval.unref?.()
+  return interval
 }
 
 function decodeHtmlEntities(value) {
@@ -101,16 +165,40 @@ function normalizeReleaseNotes(releaseNotes) {
   return null
 }
 
-function cacheUpdateMetadata(info) {
+function isNewerVersion(candidateVersion, currentVersion) {
+  const candidate = semver.valid(candidateVersion)
+  const current = semver.valid(currentVersion)
+  return Boolean(candidate && current && semver.gt(candidate, current))
+}
+
+function isVersionAllowedForChannel(version, updateChannel) {
+  const validVersion = semver.valid(version)
+  if (!validVersion) return false
+  const prerelease = semver.prerelease(validVersion)
+  if (updateChannel === 'stable') return prerelease === null
+  return prerelease === null || prerelease[0] === 'beta'
+}
+
+function isEligibleUpdate(candidateVersion, currentVersion) {
+  return isNewerVersion(candidateVersion, currentVersion)
+    && isVersionAllowedForChannel(candidateVersion, updaterState.updateChannel)
+}
+
+function cacheUpdateMetadata(info, { downloaded = false } = {}) {
   if (!info || typeof info !== 'object') return
 
   if (typeof info.version === 'string' && info.version.length > 0) {
-    const isNewVersion = updaterState.downloadedVersion && updaterState.downloadedVersion !== info.version
+    const isNewVersion = updaterState.availableVersion
+      && updaterState.availableVersion !== info.version
     if (isNewVersion) {
       updaterState.releaseName = null
       updaterState.releaseNotes = null
+      updaterState.downloadedVersion = null
     }
-    updaterState.downloadedVersion = info.version
+    updaterState.availableVersion = info.version
+    if (downloaded) {
+      updaterState.downloadedVersion = info.version
+    }
   }
 
   if (Object.prototype.hasOwnProperty.call(info, 'releaseName')) {
@@ -128,7 +216,7 @@ function buildUpdatePayload(info = {}) {
   const normalizedReleaseNotes = normalizeReleaseNotes(info?.releaseNotes)
 
   return {
-    version: info?.version || updaterState.downloadedVersion || undefined,
+    version: info?.version || updaterState.availableVersion || updaterState.downloadedVersion || undefined,
     releaseName: info?.releaseName || updaterState.releaseName || undefined,
     releaseNotes: normalizedReleaseNotes || updaterState.releaseNotes || undefined,
   }
@@ -140,25 +228,36 @@ function sendUpdateEvent(getMainWindow, channel, payload) {
   mainWindow.webContents.send(channel, payload)
 }
 
-function registerUpdateIpcHandlers({ ipcMain, autoUpdater, app, isDev, getMainWindow, prepareForUpdateQuit }) {
+function registerUpdateIpcHandlers({
+  ipcMain,
+  autoUpdater,
+  app,
+  isDev,
+  getMainWindow,
+  prepareForUpdateQuit,
+}) {
   ipcMain.handle('check-for-update', async () => {
-    if (IS_E2E) {
-      return { updateAvailable: false }
-    }
-    if (isDev) {
+    if (!canUseAutoUpdater({ app, isDev })) {
       return { updateAvailable: false }
     }
 
     try {
       const result = await autoUpdater.checkForUpdates()
-      cacheUpdateMetadata(result?.updateInfo)
-      return {
-        updateAvailable: result?.updateInfo?.version !== app.getVersion(),
-        ...buildUpdatePayload(result?.updateInfo),
+      const updateInfo = result?.updateInfo
+      const updateAvailable = isEligibleUpdate(updateInfo?.version, app.getVersion())
+      if (updateAvailable) {
+        cacheUpdateMetadata(updateInfo)
       }
-    } catch (err) {
-      console.error('Failed to check for updates:', err)
-      return { updateAvailable: false, error: err instanceof Error ? err.message : String(err) }
+      return {
+        updateAvailable,
+        ...(updateAvailable ? buildUpdatePayload(updateInfo) : {}),
+      }
+    } catch (error) {
+      console.error('Failed to check for updates:', error)
+      return {
+        updateAvailable: false,
+        error: error instanceof Error ? error.message : String(error),
+      }
     }
   })
 
@@ -169,11 +268,12 @@ function registerUpdateIpcHandlers({ ipcMain, autoUpdater, app, isDev, getMainWi
     if (isDev) {
       return { success: false, error: 'Updates disabled in development' }
     }
-
     if (process.windowsStore) {
       return { success: false, error: 'Updates are managed by Microsoft Store builds' }
     }
-
+    if (!isEligibleUpdate(updaterState.availableVersion, app.getVersion())) {
+      return { success: false, error: 'No newer update is ready to install' }
+    }
     if (updaterState.installing) {
       return { success: true, alreadyInProgress: true }
     }
@@ -196,37 +296,40 @@ function registerUpdateIpcHandlers({ ipcMain, autoUpdater, app, isDev, getMainWi
         )
       }, 45000)
 
-      // If we don't already have a ready update, ensure one is downloaded first.
-      if (!updaterState.downloadedVersion) {
+      if (!isEligibleUpdate(updaterState.downloadedVersion, app.getVersion())) {
         await autoUpdater.downloadUpdate()
       }
+      if (!isEligibleUpdate(updaterState.downloadedVersion, app.getVersion())) {
+        throw new Error('The update has not finished downloading')
+      }
 
-      // Install is explicitly user-triggered from renderer UI.
-      // Important: mark app as quitting-for-update before calling quitAndInstall.
-      // electron-updater may close windows before app's before-quit event fires.
       if (typeof prepareForUpdateQuit === 'function') {
         prepareForUpdateQuit()
       }
       autoUpdater.quitAndInstall()
       return { success: true }
-    } catch (err) {
+    } catch (error) {
       updaterState.installing = false
       if (updaterState.installTimeout) {
         clearTimeout(updaterState.installTimeout)
         updaterState.installTimeout = null
       }
-      console.error('Failed to download/install update:', err)
-      return { success: false, error: err instanceof Error ? err.message : String(err) }
+      console.error('Failed to download/install update:', error)
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
     }
   })
 }
 
-function wireAutoUpdaterEvents({ autoUpdater, getMainWindow }) {
+function wireAutoUpdaterEvents({ autoUpdater, app, getMainWindow }) {
   autoUpdater.on('checking-for-update', () => {
     sendUpdateEvent(getMainWindow, 'update-checking')
   })
 
   autoUpdater.on('update-available', (info) => {
+    if (!isEligibleUpdate(info?.version, app.getVersion())) {
+      console.log('Ignoring ineligible update:', info?.version)
+      return
+    }
     cacheUpdateMetadata(info)
     console.log('Update available:', info.version)
     sendUpdateEvent(getMainWindow, 'update-available', buildUpdatePayload(info))
@@ -246,25 +349,44 @@ function wireAutoUpdaterEvents({ autoUpdater, getMainWindow }) {
   })
 
   autoUpdater.on('update-downloaded', (info) => {
-    cacheUpdateMetadata(info)
+    if (!isEligibleUpdate(info?.version, app.getVersion())) {
+      console.log('Ignoring ineligible downloaded update:', info?.version)
+      return
+    }
+    cacheUpdateMetadata(info, { downloaded: true })
     console.log('Update downloaded:', info.version)
     sendUpdateEvent(getMainWindow, 'update-downloaded', buildUpdatePayload(info))
     console.log('Update ready to install; awaiting explicit user action')
   })
 
-  autoUpdater.on('error', (err) => {
+  autoUpdater.on('error', (error) => {
     updaterState.installing = false
     if (updaterState.installTimeout) {
       clearTimeout(updaterState.installTimeout)
       updaterState.installTimeout = null
     }
-    console.error('Auto-updater error:', err)
-    sendUpdateEvent(getMainWindow, 'update-error', err instanceof Error ? err.message : String(err))
+    console.error('Auto-updater error:', error)
+    sendUpdateEvent(
+      getMainWindow,
+      'update-error',
+      error instanceof Error ? error.message : String(error),
+    )
   })
 }
 
 module.exports = {
-  setupAutoUpdater,
+  DEFAULT_UPDATE_CHANNEL,
+  UPDATE_CHANNELS,
+  applyUpdateChannel,
+  canUseAutoUpdater,
+  configureUpdateChannel,
+  getFeedChannel,
+  inferUpdateChannelFromVersion,
+  isEligibleUpdate,
+  isNewerVersion,
+  isVersionAllowedForChannel,
+  normalizeUpdateChannel,
   registerUpdateIpcHandlers,
+  setupAutoUpdater,
   wireAutoUpdaterEvents,
 }

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "stellaris-companion",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellaris-companion",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "electron-store": "^8.1.0",
         "electron-updater": "^6.1.0",
+        "semver": "^7.8.5",
         "ws": "^8.19.0"
       },
       "devDependencies": {
@@ -68,9 +69,9 @@
       }
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -79,9 +80,9 @@
       }
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -111,6 +112,16 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@electron/notarize": {
@@ -260,9 +271,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -300,9 +311,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -564,9 +575,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -682,9 +693,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -880,19 +891,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/app-builder-lib/node_modules/universalify": {
@@ -1117,9 +1115,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1560,18 +1558,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/conf/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/config-file-ts": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz",
@@ -1605,13 +1591,13 @@
       }
     },
     "node_modules/config-file-ts/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1864,9 +1850,9 @@
       }
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1875,9 +1861,9 @@
       }
     },
     "node_modules/dir-compare/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2479,9 +2465,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -2557,17 +2543,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2728,9 +2714,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2739,9 +2725,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2768,20 +2754,6 @@
       },
       "engines": {
         "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/globalthis": {
@@ -2901,9 +2873,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3289,9 +3261,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3446,9 +3418,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4013,13 +3985,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -4085,9 +4059,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4105,19 +4079,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -4394,9 +4355,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellaris-companion",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Desktop companion app for Stellaris - AI-powered strategic advisor",
   "main": "main.js",
   "author": "Stellaris Companion",
@@ -22,6 +22,7 @@
   "dependencies": {
     "electron-store": "^8.1.0",
     "electron-updater": "^6.1.0",
+    "semver": "^7.8.5",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/electron/release-notes.md
+++ b/electron/release-notes.md
@@ -1,4 +1,5 @@
 - Let the galaxy bear witness: publish your empire's Chronicle as a shareable web story.
+- Linux commanders using Steam Play can now have their empires discovered automatically.
 - Choose Stable or Beta updates in Settings to decide when new features reach your command deck.
 - Improved update reliability across Intel and Apple silicon Macs.
 - Strengthened local credential protection and release integrity.

--- a/electron/release-notes.md
+++ b/electron/release-notes.md
@@ -1,6 +1,4 @@
-- Improved compatibility with the latest Stellaris 4.4 saves.
-- Fixed multiplayer saves sometimes showing the wrong player empire.
-- Improved accuracy for population, fleets, leaders, and known empires.
-- Made save scanning, Chronicle updates, and Advisor recommendations more reliable.
-
-Special thanks to [@will-o-matic](https://github.com/will-o-matic) for reporting and helping fix these issues.
+- Let the galaxy bear witness: publish your empire's Chronicle as a shareable web story.
+- Choose Stable or Beta updates in Settings to decide when new features reach your command deck.
+- Improved update reliability across Intel and Apple silicon Macs.
+- Strengthened local credential protection and release integrity.

--- a/electron/renderer/hooks/useSettings.ts
+++ b/electron/renderer/hooks/useSettings.ts
@@ -9,6 +9,9 @@ export const DEFAULT_CHRONICLE_REFRESH_MODE: ChronicleRefreshMode = 'balanced'
 export const MODEL_ROUTING_MODE_VALUES = ['quality_first', 'conserve'] as const
 export type ModelRoutingMode = (typeof MODEL_ROUTING_MODE_VALUES)[number]
 export const DEFAULT_MODEL_ROUTING_MODE: ModelRoutingMode = 'conserve'
+export const UPDATE_CHANNEL_VALUES = ['stable', 'beta'] as const
+export type UpdateChannel = (typeof UPDATE_CHANNEL_VALUES)[number]
+export const DEFAULT_UPDATE_CHANNEL: UpdateChannel = 'stable'
 export const LANGUAGE_VALUES = [
   'system',
   'en',
@@ -50,6 +53,12 @@ export function normalizeModelRoutingMode(rawValue: unknown): ModelRoutingMode {
     : DEFAULT_MODEL_ROUTING_MODE
 }
 
+export function normalizeUpdateChannel(rawValue: unknown): UpdateChannel {
+  return (UPDATE_CHANNEL_VALUES as readonly unknown[]).includes(rawValue)
+    ? rawValue as UpdateChannel
+    : DEFAULT_UPDATE_CHANNEL
+}
+
 export function normalizeLanguage(rawValue: unknown): LanguageSetting {
   if (typeof rawValue !== 'string') return DEFAULT_LANGUAGE
   const normalized = rawValue.trim()
@@ -70,6 +79,8 @@ export function normalizeResolvedLanguage(rawValue: unknown): ResolvedLanguage {
 export interface Settings {
   googleApiKey: string
   googleApiKeySet: boolean
+  secretStorageAvailable: boolean
+  secretStorageBackend: string | null
   discordToken: string
   discordTokenSet: boolean
   saveDir: string
@@ -87,6 +98,7 @@ export interface Settings {
   modelRoutingMode: ModelRoutingMode
   language: LanguageSetting
   resolvedLanguage: ResolvedLanguage
+  updateChannel: UpdateChannel
 }
 
 export interface UseSettingsResult {
@@ -119,6 +131,9 @@ export function useSettings(): UseSettingsResult {
         modelRoutingMode?: unknown
         language?: unknown
         resolvedLanguage?: unknown
+        updateChannel?: unknown
+        secretStorageAvailable?: unknown
+        secretStorageBackend?: unknown
       }
       const parsedUiScale = Number(loaded.uiScale)
       const normalized: Settings = {
@@ -132,6 +147,11 @@ export function useSettings(): UseSettingsResult {
         modelRoutingMode: normalizeModelRoutingMode(loaded.modelRoutingMode),
         language: normalizeLanguage(loaded.language),
         resolvedLanguage: normalizeResolvedLanguage(loaded.resolvedLanguage),
+        updateChannel: normalizeUpdateChannel(loaded.updateChannel),
+        secretStorageAvailable: loaded.secretStorageAvailable === true,
+        secretStorageBackend: typeof loaded.secretStorageBackend === 'string'
+          ? loaded.secretStorageBackend
+          : null,
       }
       setSettings(normalized)
       setError(null)

--- a/electron/renderer/i18n/locales/de/common.json
+++ b/electron/renderer/i18n/locales/de/common.json
@@ -259,12 +259,14 @@
       "intelligence": "AUFKLAERUNGS-UPLINK",
       "data": "DATENAUFNAHME",
       "communications": "KOMMUNIKATIONSRELAIS",
+      "updates": "SOFTWARE-UPDATES",
       "diagnostics": "DIAGNOSE"
     },
     "panels": {
       "geminiAccess": "GEMINI-MODELLZUGRIFF",
       "saveSource": "SPEICHERDATEI-QUELLE",
-      "discordLink": "DISCORD-VERBINDUNG"
+      "discordLink": "DISCORD-VERBINDUNG",
+      "updateChannel": "UPDATE-KANAL"
     },
     "api": {
       "label": "API-SCHLUESSEL",
@@ -273,7 +275,8 @@
       "status": "STATUS:",
       "active": "AKTIV",
       "missing": "FEHLT",
-      "generateKey": "SCHLUESSEL ERSTELLEN >"
+      "generateKey": "SCHLUESSEL ERSTELLEN >",
+      "storageWarning": "Geschuetzte Anmeldedatenspeicherung ist nicht verfuegbar. API-Schluessel bleiben nur bis zum Schliessen der App verfuegbar; das Veroeffentlichen der Chronik ist deaktiviert."
     },
     "chronicleRefresh": {
       "label": "CHRONIK-AKTUALISIERUNG",
@@ -315,6 +318,19 @@
     "feedback": {
       "label": "SYSTEMBERICHTE",
       "body": "Detaillierte Logs zur Analyse senden."
+    },
+    "updateChannel": {
+      "label": "RELEASE-KANAL",
+      "stable": "Stabil",
+      "beta": "Beta",
+      "stableTag": "EMPFOHLEN",
+      "betaTag": "VORABZUGANG",
+      "stableHelp": "Getestete Versionen fuer das taegliche Spiel.",
+      "betaHelp": "Kommende Funktionen und Korrekturen vor der stabilen Version testen.",
+      "betaWarning": "Beta-Versionen koennen weniger zuverlaessig sein. Die Rueckkehr zu Stabil erfolgt, sobald eine neuere stabile Version verfuegbar ist.",
+      "aria": "Update-Kanal {{channel}} verwenden",
+      "toastError": "Update-Kanal konnte nicht geaendert werden. Bitte erneut versuchen.",
+      "toastSuccess": "Update-Kanal auf {{channel}} gesetzt."
     },
     "actionBar": {
       "unsaved": "UNGESPEICHERTE AENDERUNGEN",

--- a/electron/renderer/i18n/locales/en-XA/common.json
+++ b/electron/renderer/i18n/locales/en-XA/common.json
@@ -238,12 +238,14 @@
       "intelligence": "[!! INTELLIGENCE UPLINK !!]",
       "data": "[!! DATA INGESTION !!]",
       "communications": "[!! COMMUNICATIONS RELAY !!]",
+      "updates": "[!! SOFTWARE UPDATES !!]",
       "diagnostics": "[!! DIAGNOSTICS !!]"
     },
     "panels": {
       "geminiAccess": "[!! GEMINI MODEL ACCESS !!]",
       "saveSource": "[!! SAVE FILE SOURCE !!]",
-      "discordLink": "[!! DISCORD LINK !!]"
+      "discordLink": "[!! DISCORD LINK !!]",
+      "updateChannel": "[!! UPDATE TRACK !!]"
     },
     "api": {
       "label": "[!! API KEY TOKEN !!]",
@@ -252,7 +254,8 @@
       "status": "[!! STATUS: !!]",
       "active": "[!! ACTIVE !!]",
       "missing": "[!! MISSING !!]",
-      "generateKey": "[!! GENERATE KEY > !!]"
+      "generateKey": "[!! GENERATE KEY > !!]",
+      "storageWarning": "[!! Protected credential storage is unavailable. API keys remain available only until you close the app, and Chronicle publishing is disabled. !!]"
     },
     "chronicleRefresh": {
       "label": "[!! CHRONICLE REFRESH !!]",
@@ -294,6 +297,19 @@
     "feedback": {
       "label": "[!! SYSTEM REPORTING !!]",
       "body": "[!! Submit detailed logs for analysis. !!]"
+    },
+    "updateChannel": {
+      "label": "[!! RELEASE CHANNEL !!]",
+      "stable": "[!! Stable !!]",
+      "beta": "[!! Beta !!]",
+      "stableTag": "[!! RECOMMENDED !!]",
+      "betaTag": "[!! EARLY ACCESS !!]",
+      "stableHelp": "[!! Tested releases for everyday play. !!]",
+      "betaHelp": "[!! Preview upcoming features and fixes before their stable release. !!]",
+      "betaWarning": "[!! Beta builds may be less reliable. Returning to Stable takes effect when a newer stable release is available. !!]",
+      "aria": "[!! Use the {{channel}} update channel !!]",
+      "toastError": "[!! Failed to change the update channel. Please try again. !!]",
+      "toastSuccess": "[!! Update channel set to {{channel}}. !!]"
     },
     "actionBar": {
       "unsaved": "[!! UNSAVED CHANGES !!]",

--- a/electron/renderer/i18n/locales/en/common.json
+++ b/electron/renderer/i18n/locales/en/common.json
@@ -258,15 +258,17 @@
     "sections": {
       "intelligence": "INTELLIGENCE UPLINK",
       "data": "DATA INGESTION",
-      "mcpRelay": "MCP RELAY",
-      "communications": "COMMUNICATIONS RELAY",
-      "diagnostics": "DIAGNOSTICS"
+    "mcpRelay": "MCP RELAY",
+    "communications": "COMMUNICATIONS RELAY",
+    "updates": "SOFTWARE UPDATES",
+    "diagnostics": "DIAGNOSTICS"
     },
     "panels": {
       "geminiAccess": "GEMINI MODEL ACCESS",
       "saveSource": "SAVE FILE SOURCE",
-      "mcpRelay": "AI APP CONNECTIONS",
-      "discordLink": "DISCORD LINK"
+    "mcpRelay": "AI APP CONNECTIONS",
+    "discordLink": "DISCORD LINK",
+    "updateChannel": "UPDATE TRACK"
     },
     "api": {
       "label": "API KEY TOKEN",
@@ -274,8 +276,9 @@
       "placeholderEmpty": "ENTER KEY",
       "status": "STATUS:",
       "active": "ACTIVE",
-      "missing": "MISSING",
-      "generateKey": "GENERATE KEY >"
+    "missing": "MISSING",
+    "generateKey": "GENERATE KEY >",
+    "storageWarning": "Protected credential storage is unavailable. API keys remain available only until you close the app, and Chronicle publishing is disabled."
     },
     "geminiQuota": {
       "label": "GEMINI QUOTA",
@@ -369,9 +372,22 @@
       "installSuccess": "Claude Desktop connection updated. Restart Claude Desktop to load it.",
       "installError": "Failed to update the Claude Desktop connection."
     },
-    "feedback": {
+  "feedback": {
       "label": "SYSTEM REPORTING",
       "body": "Submit detailed logs for analysis."
+    },
+    "updateChannel": {
+      "label": "RELEASE CHANNEL",
+      "stable": "Stable",
+      "beta": "Beta",
+      "stableTag": "RECOMMENDED",
+      "betaTag": "EARLY ACCESS",
+      "stableHelp": "Tested releases for everyday play.",
+      "betaHelp": "Preview upcoming features and fixes before their stable release.",
+      "betaWarning": "Beta builds may be less reliable. Returning to Stable takes effect when a newer stable release is available.",
+      "aria": "Use the {{channel}} update channel",
+      "toastError": "Failed to change the update channel. Please try again.",
+      "toastSuccess": "Update channel set to {{channel}}."
     },
     "actionBar": {
       "unsaved": "UNSAVED CHANGES",

--- a/electron/renderer/i18n/locales/es/common.json
+++ b/electron/renderer/i18n/locales/es/common.json
@@ -259,12 +259,14 @@
       "intelligence": "ENLACE DE INTELIGENCIA",
       "data": "INGESTA DE DATOS",
       "communications": "RELE DE COMUNICACIONES",
+      "updates": "ACTUALIZACIONES DE SOFTWARE",
       "diagnostics": "DIAGNOSTICO"
     },
     "panels": {
       "geminiAccess": "ACCESO AL MODELO GEMINI",
       "saveSource": "FUENTE DE GUARDADO",
-      "discordLink": "ENLACE DISCORD"
+      "discordLink": "ENLACE DISCORD",
+      "updateChannel": "CANAL DE ACTUALIZACION"
     },
     "api": {
       "label": "CLAVE API",
@@ -273,7 +275,8 @@
       "status": "ESTADO:",
       "active": "ACTIVO",
       "missing": "FALTA",
-      "generateKey": "GENERAR CLAVE >"
+      "generateKey": "GENERAR CLAVE >",
+      "storageWarning": "El almacenamiento protegido de credenciales no esta disponible. Las claves API solo estaran disponibles hasta que cierres la aplicacion y la publicacion de la Cronica estara desactivada."
     },
     "chronicleRefresh": {
       "label": "ACTUALIZACION DE CRONICA",
@@ -315,6 +318,19 @@
     "feedback": {
       "label": "INFORMES DEL SISTEMA",
       "body": "Enviar registros detallados para analisis."
+    },
+    "updateChannel": {
+      "label": "CANAL DE VERSION",
+      "stable": "Estable",
+      "beta": "Beta",
+      "stableTag": "RECOMENDADO",
+      "betaTag": "ACCESO ANTICIPADO",
+      "stableHelp": "Versiones probadas para jugar cada dia.",
+      "betaHelp": "Prueba proximas funciones y correcciones antes de su version estable.",
+      "betaWarning": "Las versiones beta pueden ser menos fiables. El regreso a Estable se aplicara cuando haya una version estable mas reciente.",
+      "aria": "Usar el canal de actualizacion {{channel}}",
+      "toastError": "No se pudo cambiar el canal de actualizacion. Intentalo de nuevo.",
+      "toastSuccess": "Canal de actualizacion establecido en {{channel}}."
     },
     "actionBar": {
       "unsaved": "CAMBIOS SIN GUARDAR",

--- a/electron/renderer/i18n/locales/fr/common.json
+++ b/electron/renderer/i18n/locales/fr/common.json
@@ -259,12 +259,14 @@
       "intelligence": "LIAISON DE RENSEIGNEMENT",
       "data": "INGESTION DES DONNEES",
       "communications": "RELAIS COMMUNICATIONS",
+      "updates": "MISES A JOUR LOGICIELLES",
       "diagnostics": "DIAGNOSTIC"
     },
     "panels": {
       "geminiAccess": "ACCES AU MODELE GEMINI",
       "saveSource": "SOURCE DE SAUVEGARDE",
-      "discordLink": "LIEN DISCORD"
+      "discordLink": "LIEN DISCORD",
+      "updateChannel": "CANAL DE MISE A JOUR"
     },
     "api": {
       "label": "CLE API",
@@ -273,7 +275,8 @@
       "status": "ETAT :",
       "active": "ACTIF",
       "missing": "MANQUANT",
-      "generateKey": "GENERER UNE CLE >"
+      "generateKey": "GENERER UNE CLE >",
+      "storageWarning": "Le stockage protege des identifiants est indisponible. Les cles API restent disponibles jusqu'a la fermeture de l'application et la publication de la Chronique est desactivee."
     },
     "chronicleRefresh": {
       "label": "ACTUALISATION CHRONIQUE",
@@ -315,6 +318,19 @@
     "feedback": {
       "label": "RAPPORT SYSTEME",
       "body": "Envoyer des journaux detailles pour analyse."
+    },
+    "updateChannel": {
+      "label": "CANAL DE VERSION",
+      "stable": "Stable",
+      "beta": "Beta",
+      "stableTag": "RECOMMANDE",
+      "betaTag": "ACCES ANTICIPE",
+      "stableHelp": "Versions testees pour jouer au quotidien.",
+      "betaHelp": "Decouvrez les fonctionnalites et correctifs avant leur sortie stable.",
+      "betaWarning": "Les versions beta peuvent etre moins fiables. Le retour au canal Stable prendra effet lorsqu'une version stable plus recente sera disponible.",
+      "aria": "Utiliser le canal de mise a jour {{channel}}",
+      "toastError": "Impossible de changer le canal de mise a jour. Reessayez.",
+      "toastSuccess": "Canal de mise a jour defini sur {{channel}}."
     },
     "actionBar": {
       "unsaved": "MODIFICATIONS NON ENREGISTREES",

--- a/electron/renderer/i18n/locales/ja/common.json
+++ b/electron/renderer/i18n/locales/ja/common.json
@@ -259,12 +259,14 @@
       "intelligence": "情報アップリンク",
       "data": "データ取り込み",
       "communications": "通信リレー",
+      "updates": "ソフトウェア更新",
       "diagnostics": "診断"
     },
     "panels": {
       "geminiAccess": "Gemini モデルアクセス",
       "saveSource": "セーブファイルの場所",
-      "discordLink": "Discord 接続"
+      "discordLink": "Discord 接続",
+      "updateChannel": "更新トラック"
     },
     "api": {
       "label": "API キー",
@@ -273,7 +275,8 @@
       "status": "状態:",
       "active": "有効",
       "missing": "未設定",
-      "generateKey": "キーを生成 >"
+      "generateKey": "キーを生成 >",
+      "storageWarning": "保護された認証情報ストレージを利用できません。API キーはアプリを閉じるまでのみ保持され、年代記の公開は無効になります。"
     },
     "chronicleRefresh": {
       "label": "年代記の更新",
@@ -315,6 +318,19 @@
     "feedback": {
       "label": "システム報告",
       "body": "分析用に詳細ログを送信します。"
+    },
+    "updateChannel": {
+      "label": "リリースチャンネル",
+      "stable": "安定版",
+      "beta": "ベータ",
+      "stableTag": "推奨",
+      "betaTag": "先行アクセス",
+      "stableHelp": "日常のプレイ向けにテスト済みのリリースです。",
+      "betaHelp": "安定版の公開前に新機能と修正を試せます。",
+      "betaWarning": "ベータ版は安定性が低い場合があります。安定版への復帰は、より新しい安定版が公開された時点で有効になります。",
+      "aria": "{{channel}}更新チャンネルを使用",
+      "toastError": "更新チャンネルを変更できませんでした。もう一度お試しください。",
+      "toastSuccess": "更新チャンネルを{{channel}}に設定しました。"
     },
     "actionBar": {
       "unsaved": "未保存の変更",

--- a/electron/renderer/i18n/locales/pt-BR/common.json
+++ b/electron/renderer/i18n/locales/pt-BR/common.json
@@ -259,12 +259,14 @@
       "intelligence": "UPLINK DE INTELIGENCIA",
       "data": "INGESTAO DE DADOS",
       "communications": "RELE DE COMUNICACOES",
+      "updates": "ATUALIZACOES DE SOFTWARE",
       "diagnostics": "DIAGNOSTICO"
     },
     "panels": {
       "geminiAccess": "ACESSO AO MODELO GEMINI",
       "saveSource": "FONTE DO SAVE",
-      "discordLink": "LINK DO DISCORD"
+      "discordLink": "LINK DO DISCORD",
+      "updateChannel": "CANAL DE ATUALIZACAO"
     },
     "api": {
       "label": "CHAVE API",
@@ -273,7 +275,8 @@
       "status": "STATUS:",
       "active": "ATIVO",
       "missing": "AUSENTE",
-      "generateKey": "GERAR CHAVE >"
+      "generateKey": "GERAR CHAVE >",
+      "storageWarning": "O armazenamento protegido de credenciais nao esta disponivel. As chaves de API ficam disponiveis apenas ate o app ser fechado, e a publicacao da Cronica fica desativada."
     },
     "chronicleRefresh": {
       "label": "ATUALIZACAO DA CRONICA",
@@ -315,6 +318,19 @@
     "feedback": {
       "label": "RELATORIOS DO SISTEMA",
       "body": "Enviar logs detalhados para analise."
+    },
+    "updateChannel": {
+      "label": "CANAL DE VERSAO",
+      "stable": "Estavel",
+      "beta": "Beta",
+      "stableTag": "RECOMENDADO",
+      "betaTag": "ACESSO ANTECIPADO",
+      "stableHelp": "Versoes testadas para jogar no dia a dia.",
+      "betaHelp": "Experimente proximos recursos e correcoes antes da versao estavel.",
+      "betaWarning": "Versoes beta podem ser menos confiaveis. A volta ao canal Estavel ocorrera quando uma versao estavel mais recente estiver disponivel.",
+      "aria": "Usar o canal de atualizacao {{channel}}",
+      "toastError": "Nao foi possivel alterar o canal de atualizacao. Tente novamente.",
+      "toastSuccess": "Canal de atualizacao definido como {{channel}}."
     },
     "actionBar": {
       "unsaved": "ALTERACOES NAO SALVAS",

--- a/electron/renderer/i18n/locales/zh-Hans/common.json
+++ b/electron/renderer/i18n/locales/zh-Hans/common.json
@@ -259,12 +259,14 @@
       "intelligence": "情报上行链路",
       "data": "数据摄取",
       "communications": "通信中继",
+      "updates": "软件更新",
       "diagnostics": "诊断"
     },
     "panels": {
       "geminiAccess": "Gemini 模型访问",
       "saveSource": "存档来源",
-      "discordLink": "Discord 连接"
+      "discordLink": "Discord 连接",
+      "updateChannel": "更新轨道"
     },
     "api": {
       "label": "API 密钥",
@@ -273,7 +275,8 @@
       "status": "状态：",
       "active": "已启用",
       "missing": "缺失",
-      "generateKey": "生成密钥 >"
+      "generateKey": "生成密钥 >",
+      "storageWarning": "受保护的凭据存储不可用。API 密钥仅在关闭应用前可用，编年史发布功能将被禁用。"
     },
     "chronicleRefresh": {
       "label": "编年史刷新",
@@ -315,6 +318,19 @@
     "feedback": {
       "label": "系统报告",
       "body": "提交详细日志用于分析。"
+    },
+    "updateChannel": {
+      "label": "发布频道",
+      "stable": "稳定版",
+      "beta": "测试版",
+      "stableTag": "推荐",
+      "betaTag": "抢先体验",
+      "stableHelp": "经过测试，适合日常游戏的版本。",
+      "betaHelp": "在稳定版发布前体验即将推出的功能和修复。",
+      "betaWarning": "测试版的稳定性可能较低。切回稳定版将在更新的稳定版本发布后生效。",
+      "aria": "使用{{channel}}更新频道",
+      "toastError": "无法更改更新频道，请重试。",
+      "toastSuccess": "更新频道已设为{{channel}}。"
     },
     "actionBar": {
       "unsaved": "有未保存更改",

--- a/electron/renderer/pages/SettingsPage.tsx
+++ b/electron/renderer/pages/SettingsPage.tsx
@@ -4,16 +4,19 @@ import {
   DEFAULT_CHRONICLE_REFRESH_MODE,
   DEFAULT_LANGUAGE,
   DEFAULT_MODEL_ROUTING_MODE,
+  DEFAULT_UPDATE_CHANNEL,
   DEFAULT_UI_THEME,
   normalizeChronicleRefreshMode,
   normalizeLanguage,
   normalizeModelRoutingMode,
   normalizeResolvedLanguage,
+  normalizeUpdateChannel,
   normalizeUiTheme,
   type ChronicleRefreshMode,
   type LanguageSetting,
   type ModelRoutingMode,
   type ResolvedLanguage,
+  type UpdateChannel,
   type UiTheme,
   useSettings,
 } from '../hooks/useSettings'
@@ -116,6 +119,8 @@ function SettingsPage({
   const [modelRoutingModeSaving, setModelRoutingModeSaving] = useState(false)
   const [language, setLanguage] = useState<LanguageSetting>(DEFAULT_LANGUAGE)
   const [languageSaving, setLanguageSaving] = useState(false)
+  const [updateChannel, setUpdateChannel] = useState<UpdateChannel>(DEFAULT_UPDATE_CHANNEL)
+  const [updateChannelSaving, setUpdateChannelSaving] = useState(false)
   const [hasChanges, setHasChanges] = useState(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
   const [mcpRelayStatus, setMcpRelayStatus] = useState<McpRelayStatus | null>(null)
@@ -146,10 +151,12 @@ function SettingsPage({
       const normalizedModelRoutingMode = normalizeModelRoutingMode(settings.modelRoutingMode)
       const normalizedLanguage = normalizeLanguage(settings.language)
       const normalizedResolvedLanguage = normalizeResolvedLanguage(settings.resolvedLanguage)
+      const normalizedUpdateChannel = normalizeUpdateChannel(settings.updateChannel)
       setUiTheme(normalizedTheme)
       setChronicleRefreshMode(normalizedChronicleRefreshMode)
       setModelRoutingMode(normalizedModelRoutingMode)
       setLanguage(normalizedLanguage)
+      setUpdateChannel(normalizedUpdateChannel)
       onThemeChange?.(normalizedTheme)
       onChronicleRefreshModeChange?.(normalizedChronicleRefreshMode)
       onModelRoutingModeChange?.(normalizedModelRoutingMode)
@@ -451,6 +458,35 @@ function SettingsPage({
     })
   }
 
+  const handleUpdateChannelChange = async (rawValue: string) => {
+    const nextChannel = normalizeUpdateChannel(rawValue)
+    if (nextChannel === updateChannel) return
+
+    const previousChannel = updateChannel
+    setUpdateChannel(nextChannel)
+    setUpdateChannelSaving(true)
+    const success = await saveSettings({ updateChannel: nextChannel })
+    setUpdateChannelSaving(false)
+
+    if (!success) {
+      setUpdateChannel(previousChannel)
+      showToast({
+        type: 'error',
+        message: t('settings.updateChannel.toastError'),
+        duration: 4000,
+      })
+      return
+    }
+
+    showToast({
+      type: 'success',
+      message: t('settings.updateChannel.toastSuccess', {
+        channel: t(`settings.updateChannel.${nextChannel}`),
+      }),
+      duration: 1800,
+    })
+  }
+
   const handleRetryConnection = async () => {
     if (!window.electronAPI?.discord) return
     setRetrying(true)
@@ -484,6 +520,8 @@ function SettingsPage({
   const geminiQuotaLabel = (mode: GeminiQuotaMode) => t(`settings.geminiQuota.${mode}`)
   const geminiQuotaTag = (mode: GeminiQuotaMode) => t(`settings.geminiQuota.${mode}Tag`)
   const geminiQuotaHelper = (mode: GeminiQuotaMode) => t(`settings.geminiQuota.${mode}Help`)
+  const updateChannelLabel = (channel: UpdateChannel) =>
+    t(`settings.updateChannel.${channel}`)
 
   const mcpRelayReady = Boolean(mcpRelayStatus?.databaseExists)
   const mcpRelayConfigured = Boolean(mcpRelayStatus?.claudeDesktop?.configured)
@@ -606,6 +644,11 @@ function SettingsPage({
                                 onChange={(e) => setGoogleApiKey(e.target.value)}
                                 placeholder={settings?.googleApiKeySet ? t('settings.api.placeholderSet') : t('settings.api.placeholderEmpty')}
                              />
+                             {settings && !settings.secretStorageAvailable && (
+                               <p className="border-l-2 border-accent-yellow/70 pl-3 font-mono text-[10px] leading-relaxed text-accent-yellow/80">
+                                 {t('settings.api.storageWarning')}
+                               </p>
+                             )}
                              <div className="flex justify-between items-center">
                                  <span className="font-mono text-xs text-white/30">
                                      {t('settings.api.status')} {settings?.googleApiKeySet ? <span className="text-accent-green">{t('settings.api.active')}</span> : <span className="text-accent-yellow">{t('settings.api.missing')}</span>}
@@ -1007,9 +1050,64 @@ function SettingsPage({
                     </HUDPanel>
                 </section>
 
+                {/* Software Updates Section */}
+                <section>
+                    <HUDSectionTitle number="05">{t('settings.sections.updates')}</HUDSectionTitle>
+                    <HUDPanel decoration="brackets" title={t('settings.panels.updateChannel')} quiet>
+                        <div className="space-y-3 pt-2">
+                            <div className="flex items-center justify-between gap-3">
+                                <HUDLabel>{t('settings.updateChannel.label')}</HUDLabel>
+                                {updateChannelSaving && (
+                                  <HUDMicro className="text-right">{t('common.applying')}</HUDMicro>
+                                )}
+                            </div>
+                            <div
+                              className="grid grid-cols-2 gap-2 rounded-sm border border-white/10 bg-black/20 p-1"
+                              data-testid="update-channel-control"
+                            >
+                              {(['stable', 'beta'] as const).map((channel) => {
+                                const isSelected = updateChannel === channel
+                                return (
+                                  <button
+                                    key={channel}
+                                    type="button"
+                                    disabled={updateChannelSaving}
+                                    aria-pressed={isSelected}
+                                    aria-label={t('settings.updateChannel.aria', {
+                                      channel: updateChannelLabel(channel),
+                                    })}
+                                    onClick={() => void handleUpdateChannelChange(channel)}
+                                    className={`rounded-sm border px-3 py-2 text-left transition-all duration-200 ${
+                                      isSelected
+                                        ? 'border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan'
+                                        : 'border-transparent bg-transparent text-text-secondary hover:border-white/15 hover:bg-white/5 hover:text-text-primary'
+                                    } disabled:cursor-not-allowed disabled:opacity-50`}
+                                  >
+                                    <div className="font-display text-[11px] uppercase tracking-[0.18em]">
+                                      {updateChannelLabel(channel)}
+                                    </div>
+                                    <div className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">
+                                      {t(`settings.updateChannel.${channel}Tag`)}
+                                    </div>
+                                  </button>
+                                )
+                              })}
+                            </div>
+                            <HUDMicro className="block text-[10px] leading-relaxed text-white/45 normal-case tracking-[0.02em]">
+                              {t(`settings.updateChannel.${updateChannel}Help`)}
+                            </HUDMicro>
+                            {updateChannel === 'beta' && (
+                              <p className="border-l-2 border-accent-yellow/70 pl-3 font-mono text-[10px] leading-relaxed text-accent-yellow/80">
+                                {t('settings.updateChannel.betaWarning')}
+                              </p>
+                            )}
+                        </div>
+                    </HUDPanel>
+                </section>
+
                 {/* Feedback Section */}
                 <section>
-                    <HUDSectionTitle number="05">{t('settings.sections.diagnostics')}</HUDSectionTitle>
+                    <HUDSectionTitle number="06">{t('settings.sections.diagnostics')}</HUDSectionTitle>
                     <div className="flex gap-4 items-center p-4 border border-white/5 bg-black/15 rounded-sm">
                         <div className="flex-1">
                              <HUDLabel className="block mb-1">{t('settings.feedback.label')}</HUDLabel>

--- a/electron/test/release-workflow.test.js
+++ b/electron/test/release-workflow.test.js
@@ -1,0 +1,82 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+  classifyReleaseVersion,
+  getReleaseMetadata,
+} = require('../../scripts/classify_release')
+const {
+  buildMacUpdateManifest,
+} = require('../../scripts/finalize_mac_update_manifest')
+
+test('classifies stable and beta versions into separate update feeds', () => {
+  assert.deepEqual(classifyReleaseVersion('0.8.5'), {
+    channel: 'latest',
+    prerelease: false,
+  })
+  assert.deepEqual(classifyReleaseVersion('0.9.0-beta.1'), {
+    channel: 'beta',
+    prerelease: true,
+  })
+  assert.throws(() => classifyReleaseVersion('0.9.0-alpha.1'), /Unsupported release version/)
+})
+
+test('requires the pushed tag to match the package version exactly', () => {
+  assert.deepEqual(getReleaseMetadata({
+    version: '0.8.5',
+    tag: 'v0.8.5',
+  }), {
+    version: '0.8.5',
+    tag: 'v0.8.5',
+    channel: 'latest',
+    prerelease: false,
+  })
+  assert.throws(
+    () => getReleaseMetadata({ version: '0.8.5', tag: 'v0.8.6' }),
+    /does not match package version/,
+  )
+})
+
+test('builds one architecture-complete macOS manifest for a stable release', async (t) => {
+  const assetsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stellaris-mac-update-'))
+  t.after(() => fs.rmSync(assetsDir, { recursive: true, force: true }))
+
+  fs.writeFileSync(
+    path.join(assetsDir, 'Stellaris-Companion-0.8.5-arm64-mac.zip'),
+    'arm64 archive',
+  )
+  fs.writeFileSync(
+    path.join(assetsDir, 'Stellaris-Companion-0.8.5-mac.zip'),
+    'x64 archive',
+  )
+
+  const manifest = await buildMacUpdateManifest({
+    assetsDir,
+    releaseDate: '2026-07-30T12:00:00.000Z',
+    releaseNotes: '- Publish your Chronicle.',
+    version: '0.8.5',
+  })
+
+  assert.match(manifest, /url: Stellaris-Companion-0\.8\.5-arm64-mac\.zip/)
+  assert.match(manifest, /url: Stellaris-Companion-0\.8\.5-mac\.zip/)
+  assert.doesNotMatch(manifest, /minimumSystemVersion/)
+  assert.match(manifest, /releaseNotes: \|\n  - Publish your Chronicle\./)
+})
+
+test('supports beta asset names and refuses a partial macOS manifest', async (t) => {
+  const assetsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stellaris-mac-update-'))
+  t.after(() => fs.rmSync(assetsDir, { recursive: true, force: true }))
+  fs.writeFileSync(
+    path.join(assetsDir, 'Stellaris-Companion-0.9.0-beta.1-arm64-mac.zip'),
+    'arm64 archive',
+  )
+
+  await assert.rejects(buildMacUpdateManifest({
+    assetsDir,
+    releaseNotes: '- Provider beta.',
+    version: '0.9.0-beta.1',
+  }), /Missing x64 macOS ZIP/)
+})

--- a/electron/test/save-paths.test.js
+++ b/electron/test/save-paths.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const test = require('node:test')
+
+const { getLinuxSaveDirCandidates } = require('../main/savePaths')
+
+test('includes native, Flatpak, and common Proton save locations on Linux', () => {
+  const homedir = path.join(path.sep, 'home', 'commander')
+  const candidates = getLinuxSaveDirCandidates(homedir)
+  const protonSuffix = path.join(
+    'steamapps',
+    'compatdata',
+    '281990',
+    'pfx',
+    'drive_c',
+    'users',
+    'steamuser',
+    'Documents',
+    'Paradox Interactive',
+    'Stellaris',
+    'save games',
+  )
+
+  assert.deepEqual(candidates, [
+    path.join(homedir, '.local', 'share', 'Paradox Interactive', 'Stellaris', 'save games'),
+    path.join(homedir, '.local', 'share', 'Paradox Interactive', 'Stellaris Plaza', 'save games'),
+    path.join(
+      homedir,
+      '.var',
+      'app',
+      'com.valvesoftware.Steam',
+      '.local',
+      'share',
+      'Paradox Interactive',
+      'Stellaris',
+      'save games',
+    ),
+    path.join(homedir, '.steam', 'steam', protonSuffix),
+    path.join(homedir, '.local', 'share', 'Steam', protonSuffix),
+    path.join(
+      homedir,
+      '.var',
+      'app',
+      'com.valvesoftware.Steam',
+      'data',
+      'Steam',
+      protonSuffix,
+    ),
+  ])
+})

--- a/electron/test/secure-storage.test.js
+++ b/electron/test/secure-storage.test.js
@@ -1,0 +1,97 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  createSecretStorage,
+  getSecretStorageStatus,
+} = require('../main/secureStorage')
+
+class MemoryStore {
+  constructor(initial = {}) {
+    this.values = new Map(Object.entries(initial))
+  }
+
+  get(key) {
+    return this.values.get(key)
+  }
+
+  set(key, value) {
+    this.values.set(key, value)
+  }
+
+  delete(key) {
+    this.values.delete(key)
+  }
+}
+
+function protectedSafeStorage({ backend = 'gnome_libsecret' } = {}) {
+  return {
+    isEncryptionAvailable: () => true,
+    getSelectedStorageBackend: () => backend,
+    encryptString: value => Buffer.from(`encrypted:${value}`),
+    decryptString: value => value.toString('utf8').replace(/^encrypted:/, ''),
+  }
+}
+
+test('persists secrets only when the selected backend protects data at rest', () => {
+  const store = new MemoryStore()
+  const storage = createSecretStorage({
+    safeStorage: protectedSafeStorage(),
+    store,
+    platform: 'linux',
+  })
+
+  assert.deepEqual(storage.setSecret('api-key', 'secret-value'), { persisted: true })
+  assert.equal(store.get('api-key'), Buffer.from('encrypted:secret-value').toString('base64'))
+  assert.equal(storage.getSecret('api-key'), 'secret-value')
+  assert.equal(storage.getStatus().persistentEncryptionAvailable, true)
+})
+
+test('treats Linux basic_text as unprotected and keeps new secrets in memory only', () => {
+  const store = new MemoryStore()
+  const storage = createSecretStorage({
+    safeStorage: protectedSafeStorage({ backend: 'basic_text' }),
+    store,
+    platform: 'linux',
+  })
+
+  assert.deepEqual(storage.setSecret('api-key', 'session-secret'), { persisted: false })
+  assert.equal(store.get('api-key'), undefined)
+  assert.equal(storage.getSecret('api-key'), 'session-secret')
+  assert.equal(storage.getStatus().persistentEncryptionAvailable, false)
+})
+
+test('migrates legacy insecure values out of persistent storage when read', () => {
+  const legacyValue = Buffer.from('encrypted:legacy-secret').toString('base64')
+  const store = new MemoryStore({ 'api-key': legacyValue })
+  const storage = createSecretStorage({
+    safeStorage: protectedSafeStorage({ backend: 'basic_text' }),
+    store,
+    platform: 'linux',
+  })
+
+  assert.equal(storage.getSecret('api-key'), 'legacy-secret')
+  assert.equal(store.get('api-key'), undefined)
+  assert.equal(storage.getSecret('api-key'), 'legacy-secret')
+})
+
+test('does not report encryption availability as protected storage on basic_text', () => {
+  assert.deepEqual(
+    getSecretStorageStatus(protectedSafeStorage({ backend: 'basic_text' }), 'linux'),
+    {
+      backend: 'basic_text',
+      encryptionAvailable: true,
+      persistentEncryptionAvailable: false,
+    },
+  )
+})
+
+test('fails closed when Linux cannot identify the selected storage backend', () => {
+  assert.equal(
+    getSecretStorageStatus({
+      isEncryptionAvailable: () => true,
+      getSelectedStorageBackend: () => 'unknown',
+    }, 'linux').persistentEncryptionAvailable,
+    false,
+  )
+})

--- a/electron/test/settings-locales.test.js
+++ b/electron/test/settings-locales.test.js
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const localesDir = path.join(__dirname, '..', 'renderer', 'i18n', 'locales')
+
+test('ships complete update-channel and protected-storage copy in every locale', () => {
+  for (const locale of fs.readdirSync(localesDir)) {
+    const filePath = path.join(localesDir, locale, 'common.json')
+    const messages = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    const settings = messages.settings
+
+    assert.ok(settings?.sections?.updates, `${locale}: missing Settings update section`)
+    assert.ok(settings?.panels?.updateChannel, `${locale}: missing update panel title`)
+    assert.ok(settings?.api?.storageWarning, `${locale}: missing credential warning`)
+    assert.ok(settings?.updateChannel?.stable, `${locale}: missing Stable label`)
+    assert.ok(settings?.updateChannel?.beta, `${locale}: missing Beta label`)
+    assert.ok(settings?.updateChannel?.betaWarning, `${locale}: missing Beta warning`)
+  }
+})

--- a/electron/test/updates.test.js
+++ b/electron/test/updates.test.js
@@ -1,0 +1,188 @@
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+const test = require('node:test')
+
+const {
+  applyUpdateChannel,
+  canUseAutoUpdater,
+  configureUpdateChannel,
+  inferUpdateChannelFromVersion,
+  isVersionAllowedForChannel,
+  isNewerVersion,
+  normalizeUpdateChannel,
+  registerUpdateIpcHandlers,
+  wireAutoUpdaterEvents,
+} = require('../main/updates')
+
+test('infers update preferences from stable and beta app versions', () => {
+  assert.equal(inferUpdateChannelFromVersion('0.8.5'), 'stable')
+  assert.equal(inferUpdateChannelFromVersion('0.9.0-beta.1'), 'beta')
+  assert.equal(inferUpdateChannelFromVersion('0.9.0-alpha.1'), 'stable')
+  assert.equal(inferUpdateChannelFromVersion('invalid'), 'stable')
+  assert.equal(normalizeUpdateChannel('beta', '0.8.5'), 'beta')
+  assert.equal(normalizeUpdateChannel('invalid', '0.9.0-beta.2'), 'beta')
+})
+
+test('configures updater feeds without permitting downgrades', () => {
+  const autoUpdater = {}
+
+  assert.equal(configureUpdateChannel({
+    autoUpdater,
+    updateChannel: 'beta',
+    appVersion: '0.8.5',
+  }), 'beta')
+  assert.equal(autoUpdater.channel, 'beta')
+  assert.equal(autoUpdater.allowPrerelease, true)
+  assert.equal(autoUpdater.allowDowngrade, false)
+
+  assert.equal(configureUpdateChannel({
+    autoUpdater,
+    updateChannel: 'stable',
+    appVersion: '0.9.0-beta.1',
+  }), 'stable')
+  assert.equal(autoUpdater.channel, 'latest')
+  assert.equal(autoUpdater.allowPrerelease, false)
+  assert.equal(autoUpdater.allowDowngrade, false)
+})
+
+test('checks immediately after a real packaged app changes channel', async () => {
+  let checks = 0
+  const autoUpdater = {
+    checkForUpdates: async () => {
+      checks += 1
+    },
+  }
+
+  applyUpdateChannel({
+    autoUpdater,
+    app: { isPackaged: true, getVersion: () => '0.8.5' },
+    isDev: false,
+    updateChannel: 'beta',
+    checkNow: true,
+  })
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(checks, 1)
+  assert.equal(autoUpdater.channel, 'beta')
+})
+
+test('disables updater access in unsupported runtime contexts', () => {
+  const packagedApp = { isPackaged: true }
+  assert.equal(canUseAutoUpdater({ app: packagedApp, isDev: true }), false)
+  assert.equal(canUseAutoUpdater({ app: packagedApp, isDev: false, isE2E: true }), false)
+  assert.equal(canUseAutoUpdater({
+    app: packagedApp,
+    isDev: false,
+    isE2E: false,
+    windowsStore: true,
+  }), false)
+  assert.equal(canUseAutoUpdater({
+    app: packagedApp,
+    isDev: false,
+    isE2E: false,
+    platform: 'darwin',
+    execPath: '/Volumes/Stellaris Companion/Stellaris Companion.app',
+  }), false)
+})
+
+test('compares update versions semantically', () => {
+  assert.equal(isNewerVersion('0.9.1', '0.9.0'), true)
+  assert.equal(isNewerVersion('0.10.0', '0.9.9'), true)
+  assert.equal(isNewerVersion('0.8.4', '0.9.0'), false)
+  assert.equal(isNewerVersion('0.9.0', '0.9.0'), false)
+  assert.equal(isNewerVersion('not-a-version', '0.9.0'), false)
+})
+
+test('allows only releases appropriate for the selected channel', () => {
+  assert.equal(isVersionAllowedForChannel('0.8.6', 'stable'), true)
+  assert.equal(isVersionAllowedForChannel('0.9.0-beta.1', 'stable'), false)
+  assert.equal(isVersionAllowedForChannel('0.8.6', 'beta'), true)
+  assert.equal(isVersionAllowedForChannel('0.9.0-beta.1', 'beta'), true)
+  assert.equal(isVersionAllowedForChannel('0.9.0-alpha.1', 'beta'), false)
+})
+
+test('drops a late beta download after switching back to Stable', () => {
+  const autoUpdater = new EventEmitter()
+  const sent = []
+  const mainWindow = {
+    isDestroyed: () => false,
+    webContents: {
+      send: (channel, payload) => sent.push({ channel, payload }),
+    },
+  }
+
+  wireAutoUpdaterEvents({
+    autoUpdater,
+    app: { getVersion: () => '0.8.5' },
+    getMainWindow: () => mainWindow,
+  })
+  configureUpdateChannel({
+    autoUpdater,
+    updateChannel: 'stable',
+    appVersion: '0.8.5',
+  })
+  autoUpdater.emit('update-downloaded', { version: '0.9.0-beta.1' })
+
+  assert.deepEqual(sent, [])
+})
+
+test('ignores stale updater events and forwards a newer download', () => {
+  const autoUpdater = new EventEmitter()
+  const sent = []
+  const mainWindow = {
+    isDestroyed: () => false,
+    webContents: {
+      send: (channel, payload) => sent.push({ channel, payload }),
+    },
+  }
+
+  wireAutoUpdaterEvents({
+    autoUpdater,
+    app: { isPackaged: true, getVersion: () => '0.8.5' },
+    getMainWindow: () => mainWindow,
+  })
+
+  autoUpdater.emit('update-available', { version: '0.8.4' })
+  autoUpdater.emit('update-downloaded', { version: '0.8.4' })
+  assert.deepEqual(sent, [])
+
+  autoUpdater.emit('update-downloaded', {
+    version: '0.8.6',
+    releaseNotes: '- Safer updates.',
+  })
+  assert.deepEqual(sent, [{
+    channel: 'update-downloaded',
+    payload: {
+      version: '0.8.6',
+      releaseName: undefined,
+      releaseNotes: '- Safer updates.',
+    },
+  }])
+})
+
+test('manual checks do not offer an older published release', async () => {
+  const handlers = new Map()
+  const ipcMain = {
+    handle: (channel, handler) => handlers.set(channel, handler),
+  }
+  const autoUpdater = {
+    checkForUpdates: async () => ({
+      updateInfo: {
+        version: '0.8.4',
+        releaseNotes: '- Older release.',
+      },
+    }),
+  }
+
+  registerUpdateIpcHandlers({
+    ipcMain,
+    autoUpdater,
+    app: { getVersion: () => '0.8.5' },
+    isDev: false,
+    getMainWindow: () => null,
+    prepareForUpdateQuit: () => {},
+  })
+
+  const result = await handlers.get('check-for-update')()
+  assert.deepEqual(result, { updateAvailable: false })
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellaris-companion"
-version = "0.8.4"
+version = "0.8.5"
 description = "AI-powered strategic advisor for Stellaris using Gemini"
 readme = "README.md"
 license = "MIT"
@@ -20,7 +20,7 @@ dependencies = [
     "google-genai>=1.0.0",
     # Keep macOS PyInstaller bundles on the statically-linked wheel; newer
     # runner-provided builds can dynamically link mismatched libssl.dylib.
-    "cryptography==46.0.4",
+    "cryptography==48.0.1",
     "python-dotenv>=1.0.0",
     "watchdog>=3.0",
     "fastapi>=0.100.0",

--- a/scripts/classify_release.js
+++ b/scripts/classify_release.js
@@ -1,0 +1,71 @@
+const fs = require('node:fs')
+
+function classifyReleaseVersion(version) {
+  if (/^\d+\.\d+\.\d+$/.test(version || '')) {
+    return { channel: 'latest', prerelease: false }
+  }
+  if (/^\d+\.\d+\.\d+-beta\.\d+$/.test(version || '')) {
+    return { channel: 'beta', prerelease: true }
+  }
+  throw new Error(
+    `Unsupported release version "${version || ''}". Use X.Y.Z or X.Y.Z-beta.N.`,
+  )
+}
+
+function parseArgs(argv) {
+  const args = {}
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]
+    const value = argv[index + 1]
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument: ${key || ''}`)
+    }
+    args[key.slice(2)] = value
+  }
+  return args
+}
+
+function getReleaseMetadata({ version, tag }) {
+  const classification = classifyReleaseVersion(version)
+  const expectedTag = `v${version}`
+  if (tag && tag !== expectedTag) {
+    throw new Error(`Release tag "${tag}" does not match package version "${expectedTag}".`)
+  }
+  return {
+    version,
+    tag: expectedTag,
+    channel: classification.channel,
+    prerelease: classification.prerelease,
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const metadata = getReleaseMetadata({
+    version: args.version,
+    tag: args.tag,
+  })
+  const output = Object.entries(metadata)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')
+  if (args.output) {
+    fs.appendFileSync(args.output, `${output}\n`, 'utf8')
+  } else {
+    process.stdout.write(`${output}\n`)
+  }
+}
+
+if (require.main === module) {
+  try {
+    main()
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  classifyReleaseVersion,
+  getReleaseMetadata,
+  parseArgs,
+}

--- a/scripts/finalize_mac_update_manifest.js
+++ b/scripts/finalize_mac_update_manifest.js
@@ -1,0 +1,147 @@
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const path = require('node:path')
+
+function parseArgs(argv) {
+  const args = {}
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]
+    const value = argv[index + 1]
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument: ${key || ''}`)
+    }
+    args[key.slice(2)] = value
+  }
+  return args
+}
+
+function requireFile(filePath, label) {
+  let stat
+  try {
+    stat = fs.statSync(filePath)
+  } catch {
+    throw new Error(`Missing ${label}: ${filePath}`)
+  }
+  if (!stat.isFile() || stat.size === 0) {
+    throw new Error(`Invalid ${label}: ${filePath}`)
+  }
+  return stat
+}
+
+function sha512Base64(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha512')
+    const stream = fs.createReadStream(filePath)
+    stream.on('error', reject)
+    stream.on('data', chunk => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('base64')))
+  })
+}
+
+function indentBlock(value) {
+  return value
+    .trimEnd()
+    .split('\n')
+    .map(line => `  ${line}`)
+    .join('\n')
+}
+
+async function buildMacUpdateManifest({
+  assetsDir,
+  minimumSystemVersion,
+  releaseDate,
+  releaseNotes,
+  version,
+}) {
+  if (!/^\d+\.\d+\.\d+(?:-beta\.\d+)?$/.test(version || '')) {
+    throw new Error(`Invalid release version: ${version || ''}`)
+  }
+  if (
+    minimumSystemVersion !== undefined
+    && !/^\d+(?:\.\d+){1,2}$/.test(minimumSystemVersion)
+  ) {
+    throw new Error(`Invalid minimum system version: ${minimumSystemVersion || ''}`)
+  }
+  if (!releaseNotes?.trim()) {
+    throw new Error('Release notes are required')
+  }
+
+  const normalizedDate = releaseDate || new Date().toISOString()
+  if (Number.isNaN(Date.parse(normalizedDate))) {
+    throw new Error(`Invalid release date: ${normalizedDate}`)
+  }
+
+  const assetNames = {
+    arm64: `Stellaris-Companion-${version}-arm64-mac.zip`,
+    x64: `Stellaris-Companion-${version}-mac.zip`,
+  }
+  const assets = []
+  for (const architecture of ['arm64', 'x64']) {
+    const name = assetNames[architecture]
+    const filePath = path.join(assetsDir, name)
+    const stat = requireFile(filePath, `${architecture} macOS ZIP`)
+    assets.push({
+      name,
+      sha512: await sha512Base64(filePath),
+      size: stat.size,
+    })
+  }
+
+  const x64Asset = assets.find(asset => asset.name === assetNames.x64)
+  const fileEntries = assets
+    .map(asset => [
+      `  - url: ${asset.name}`,
+      `    sha512: ${asset.sha512}`,
+      `    size: ${asset.size}`,
+    ].join('\n'))
+    .join('\n')
+
+  const lines = [
+    `version: ${version}`,
+    'files:',
+    fileEntries,
+    `path: ${x64Asset.name}`,
+    `sha512: ${x64Asset.sha512}`,
+  ]
+  if (minimumSystemVersion) {
+    lines.push(`minimumSystemVersion: ${minimumSystemVersion}`)
+  }
+  lines.push(
+    'releaseNotes: |',
+    indentBlock(releaseNotes),
+    `releaseDate: '${new Date(normalizedDate).toISOString()}'`,
+    '',
+  )
+  return lines.join('\n')
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const assetsDir = path.resolve(args['assets-dir'] || '')
+  const notesPath = path.resolve(args.notes || '')
+  const outputPath = path.resolve(args.output || '')
+  requireFile(notesPath, 'release notes')
+
+  const manifest = await buildMacUpdateManifest({
+    assetsDir,
+    minimumSystemVersion: args['minimum-system-version'],
+    releaseDate: args['release-date'],
+    releaseNotes: fs.readFileSync(notesPath, 'utf8'),
+    version: args.version,
+  })
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, manifest, 'utf8')
+  process.stdout.write(`Wrote ${outputPath}\n`)
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`)
+    process.exitCode = 1
+  })
+}
+
+module.exports = {
+  buildMacUpdateManifest,
+  parseArgs,
+}

--- a/stellaris-backend.spec
+++ b/stellaris-backend.spec
@@ -16,6 +16,7 @@ Output:
     dist/stellaris-backend.exe (Windows)
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -28,7 +29,7 @@ SPEC_ROOT = Path(SPECPATH)
 # Auto-detect macOS code signing identity (Developer ID Application)
 _codesign_identity = None
 _entitlements_file = None
-if sys.platform == 'darwin':
+if sys.platform == 'darwin' and os.environ.get('STELLARIS_SKIP_BACKEND_CODESIGN') != '1':
     _entitlements_path = SPEC_ROOT / 'electron' / 'entitlements.mac.plist'
     if _entitlements_path.exists():
         _entitlements_file = str(_entitlements_path)
@@ -50,6 +51,8 @@ if sys.platform == 'darwin':
         print(f'PyInstaller: signing with identity {_codesign_identity}')
     else:
         print('PyInstaller: no Developer ID found, skipping code signing')
+elif sys.platform == 'darwin':
+    print('PyInstaller: code signing disabled for this local build')
 
 a = Analysis(
     ['backend/electron_main.py'],

--- a/stellaris_companion/save_loader.py
+++ b/stellaris_companion/save_loader.py
@@ -13,6 +13,25 @@ from pathlib import Path
 
 from .paths import get_repo_root
 
+_PROTON_SAVE_SEGMENTS = (
+    "steamapps",
+    "compatdata",
+    "281990",
+    "pfx",
+    "drive_c",
+    "users",
+    "steamuser",
+    "Documents",
+    "Paradox Interactive",
+    "Stellaris",
+    "save games",
+)
+
+
+def _proton_save_path(steam_root: Path) -> Path:
+    return steam_root.joinpath(*_PROTON_SAVE_SEGMENTS)
+
+
 # Standard Stellaris save locations by platform
 STELLARIS_SAVE_PATHS = {
     "darwin": [  # macOS
@@ -32,6 +51,13 @@ STELLARIS_SAVE_PATHS = {
         / "Paradox Interactive"
         / "Stellaris"
         / "save games",
+        # Steam Play / Proton
+        _proton_save_path(Path.home() / ".steam" / "steam"),
+        _proton_save_path(Path.home() / ".local" / "share" / "Steam"),
+        # Flatpak Steam with Proton
+        _proton_save_path(
+            Path.home() / ".var" / "app" / "com.valvesoftware.Steam" / "data" / "Steam"
+        ),
     ],
     "win32": [
         Path.home() / "Documents" / "Paradox Interactive" / "Stellaris" / "save games",

--- a/tests/test_save_loader_platform_paths.py
+++ b/tests/test_save_loader_platform_paths.py
@@ -39,6 +39,15 @@ def test_linux_defaults_include_steam_and_flatpak_paths(monkeypatch) -> None:
         in p
         for p in rendered
     )
+    proton_suffix = (
+        "steamapps/compatdata/281990/pfx/drive_c/users/steamuser/Documents/"
+        "Paradox Interactive/Stellaris/save games"
+    )
+    assert any(f".steam/steam/{proton_suffix}" in p for p in rendered)
+    assert any(f".local/share/Steam/{proton_suffix}" in p for p in rendered)
+    assert any(
+        f".var/app/com.valvesoftware.Steam/data/Steam/{proton_suffix}" in p for p in rendered
+    )
 
 
 def test_unknown_platform_falls_back_to_darwin_defaults(monkeypatch) -> None:

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 import tomllib
@@ -13,7 +14,14 @@ def test_versions_match_across_python_and_electron_packages():
 
     electron_pkg = json.loads((repo_root / "electron" / "package.json").read_text(encoding="utf-8"))
     electron_version = electron_pkg["version"]
+    backend_init = (repo_root / "backend" / "__init__.py").read_text(encoding="utf-8")
+    backend_version_match = re.search(r'^__version__ = "([^"]+)"$', backend_init, re.MULTILINE)
 
     assert python_version == electron_version, (
         f"Version mismatch: pyproject.toml={python_version} electron/package.json={electron_version}"
+    )
+    assert backend_version_match is not None, "backend/__init__.py does not define __version__"
+    assert backend_version_match.group(1) == electron_version, (
+        f"Version mismatch: backend/__init__.py={backend_version_match.group(1)} "
+        f"electron/package.json={electron_version}"
     )


### PR DESCRIPTION
## Summary
- add an immediately persisted Stable/Beta update selector with explicit latest and beta feeds
- protect local credentials when the OS cannot provide encrypted storage
- discover Stellaris saves automatically for common Steam Play and Flatpak Proton installations on Linux
- keep release builds draft until every platform succeeds and both macOS architectures share a complete manifest
- prepare the Chronicle-focused 0.8.5 version metadata and release notes

## Validation
- 297 Python tests passed; 27 save-corpus tests skipped as expected
- 37 Rust tests passed
- 26 Electron main-process tests passed
- 6 Playwright Electron journeys passed, including Chronicle publishing and update-channel persistence
- packaged backend passed MCP and Electron boot smoke tests
- signed and notarized macOS arm64 and x64 packages completed in the manual release preflight
- Windows x64 and Linux x64 packages completed in the manual release preflight
- the Proton discovery change completed a fresh Linux x64 release preflight
- all preflight artifacts were uploaded to Actions with publishing disabled
- Python and shipped npm dependency audits report no known vulnerabilities
- all required GitHub checks pass on Linux and Windows

## Community report
Fixes #36. Thanks to @CodeMaster013 for identifying the missing Steam Play save paths and documenting the affected workflow.

## Release boundary
No v0.8.5 tag or GitHub Release has been created. Merge and the final versioned release remain manual stopping points. PR #35 stays draft for the first model-provider beta after 0.8.5.

## Follow-up risk
The full development audit still reports advisories in the Electron 28 and electron-builder 24 toolchain. Their major-version upgrade remains scoped to the provider beta so this stable release does not silently raise the macOS requirement.
