### PR TITLE
chore(release): prepare 0.9.0-beta.3

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,4 +5,4 @@ Stellaris Companion Backend
 Electron app backend with a configurable strategic advisor for Stellaris.
 """
 
-__version__ = "0.9.0-beta.2"
+__version__ = "0.9.0-beta.3"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellaris-companion",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellaris-companion",
-      "version": "0.9.0-beta.2",
+      "version": "0.9.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "electron-store": "^8.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellaris-companion",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "description": "Desktop companion app for Stellaris - AI-powered strategic advisor",
   "main": "main.js",
   "author": "Stellaris Companion",

--- a/electron/release-notes.md
+++ b/electron/release-notes.md
@@ -1,5 +1,4 @@
-- Improved compatibility with current OpenRouter and local models across both Advisor and Chronicle.
-- Added reliable starting models with easy access to OpenRouter's popular model catalog.
-- Model connection tests now confirm whether both Advisor and Chronicle are ready.
-- Improved interpretation of Stellaris 4 populations, diplomatic contacts, dormant powers, and L-Gates.
-- Chronicle chapters now stay closer to recorded campaign events while scaling detail to the story available.
+- Improved Advisor and Chronicle accuracy for current Stellaris 4.4 mechanics.
+- Added stronger guidance for populations, Trade, war participation, and Nomad economies.
+- Reduced stale or invented campaign interpretations by grounding responses in save data and verified game rules.
+- Improved Chronicle reliability when a model returns an empty or incomplete structured response.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellaris-companion"
-version = "0.9.0-beta.2"
+version = "0.9.0-beta.3"
 description = "AI-powered strategic advisor for Stellaris with configurable model providers"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump the synchronized app version to `0.9.0-beta.3`
- publish concise in-app notes for shared Stellaris game knowledge and Chronicle reliability
- keep the release on the beta update channel

## Verification
- 351 Python tests passed, 27 skipped
- Ruff lint and formatting passed
- 37 Rust tests passed; Clippy and formatting passed
- 41 Electron tests and 11 desktop journeys passed
- renderer production build passed
- release metadata classified `v0.9.0-beta.3` as a prerelease on the beta channel