### PR TITLE
Prepare Stellaris Companion 1.0.0-beta.1

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -43,10 +43,7 @@ jobs:
 
       - name: Run main-process tests
         working-directory: electron
-        run: |
-          npm run test:advisor-providers
-          npm run test:chronicle-publishing
-          npm run test:updates
+        run: npm test
 
       - name: Build renderer
         working-directory: electron

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -31,6 +31,18 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require release tags to come from main
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          git fetch origin main --no-tags
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Release tag ${{ github.ref_name }} is not attached to a commit on main." >&2
+            exit 1
+          fi
 
       - name: Validate release metadata
         id: release-metadata
@@ -62,8 +74,69 @@ jobs:
             echo "matrix=$(echo "$ALL" | jq -c --arg p "$PLATFORM" '{"include": [.include[] | select(.name == $p)]}')" >> "$GITHUB_OUTPUT"
           fi
 
-  release:
+  release_checks:
     needs: setup
+    name: Release validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip && python -m pip install '.[dev]'
+
+      - name: Lint Python
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Validate Rust parser
+        working-directory: stellaris-parser
+        run: |
+          cargo fmt --check
+          cargo clippy -- -D warnings
+          cargo test
+          cargo build --release
+
+      - name: Run Python tests
+        run: pytest tests/ --tb=short
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            electron/package-lock.json
+            electron/renderer/package-lock.json
+
+      - name: Install desktop dependencies
+        run: |
+          npm ci --prefix electron
+          npm ci --prefix electron/renderer
+
+      - name: Validate desktop app
+        run: |
+          npm test --prefix electron
+          npm run build:renderer --prefix electron
+          xvfb-run --auto-servernum npm run test:e2e --prefix electron
+        env:
+          E2E_NO_SANDBOX: '1'
+
+  release:
+    needs: [setup, release_checks]
     name: Build - ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -263,7 +336,7 @@ jobs:
           fi
 
   finalize_release:
-    needs: [setup, release]
+    needs: [setup, release_checks, release]
     if: needs.setup.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,4 +5,4 @@ Stellaris Companion Backend
 Electron app backend with a configurable strategic advisor for Stellaris.
 """
 
-__version__ = "0.9.0-beta.4"
+__version__ = "1.0.0-beta.1"

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -1237,6 +1237,8 @@ def create_app() -> FastAPI:
                 status_code=500,
                 detail={"error": f"Recap generation failed: {str(e)}"},
             )
+        finally:
+            generator.close()
 
     @app.post("/api/chronicle", dependencies=[Depends(verify_token)])
     def generate_chronicle(request: Request, body: ChronicleRequest) -> dict[str, Any]:
@@ -1310,6 +1312,7 @@ def create_app() -> FastAPI:
                 detail={"error": f"Chronicle generation failed: {str(e)}"},
             )
         finally:
+            generator.close()
             with _chronicle_in_flight_lock:
                 _chronicle_in_flight.discard(in_flight_key)
 
@@ -1364,5 +1367,7 @@ def create_app() -> FastAPI:
                 status_code=500,
                 detail={"error": f"Chapter regeneration failed: {str(e)}"},
             )
+        finally:
+            generator.close()
 
     return app

--- a/backend/core/advisor_providers.py
+++ b/backend/core/advisor_providers.py
@@ -227,6 +227,8 @@ class AdvisorGenerator(Protocol):
         allow_schema_fallback: bool = True,
     ) -> AdvisorGenerationResult: ...
 
+    def close(self) -> None: ...
+
 
 class GeminiAdvisorGenerator:
     """Native Gemini adapter retaining the existing quota fallback behavior."""
@@ -234,6 +236,11 @@ class GeminiAdvisorGenerator:
     def __init__(self, *, config: AdvisorProviderConfig, client: Any):
         self.config = config
         self.client = client
+
+    def close(self) -> None:
+        close = getattr(self.client, "close", None)
+        if callable(close):
+            close()
 
     def generate(
         self,
@@ -366,6 +373,23 @@ class OpenAICompatibleAdvisorGenerator:
     ):
         self.config = config
         self._client = client
+        self._owns_client = client is None
+
+    @property
+    def client(self) -> httpx.Client:
+        """Lazily create one connection pool for this generator's lifetime."""
+        if self._client is None:
+            self._client = httpx.Client(
+                timeout=httpx.Timeout(self.config.timeout_seconds, connect=10.0),
+                follow_redirects=False,
+            )
+        return self._client
+
+    def close(self) -> None:
+        """Close the connection pool when this generator created it."""
+        if self._owns_client and self._client is not None:
+            self._client.close()
+            self._client = None
 
     def generate(
         self,
@@ -428,14 +452,9 @@ class OpenAICompatibleAdvisorGenerator:
             if self.config.provider == ADVISOR_PROVIDER_OPENROUTER:
                 request_body["provider"] = {"require_parameters": True}
 
-        client = self._client or httpx.Client(
-            timeout=httpx.Timeout(self.config.timeout_seconds, connect=10.0),
-            follow_redirects=False,
-        )
-        close_client = self._client is None
         schema_fallback_used = False
         try:
-            response = client.post(
+            response = self.client.post(
                 f"{self.config.base_url}/chat/completions",
                 headers=headers,
                 json=request_body,
@@ -452,7 +471,7 @@ class OpenAICompatibleAdvisorGenerator:
                 fallback_body.pop("response_format", None)
                 fallback_body.pop("provider", None)
                 schema_fallback_used = True
-                response = client.post(
+                response = self.client.post(
                     f"{self.config.base_url}/chat/completions",
                     headers=headers,
                     json=fallback_body,
@@ -469,10 +488,6 @@ class OpenAICompatibleAdvisorGenerator:
                 code="PROVIDER_UNAVAILABLE",
                 status_code=503,
             ) from exc
-        finally:
-            if close_client:
-                client.close()
-
         if not response.is_success:
             error_message = _redact_sensitive_text(
                 _compatible_error_message(response),

--- a/backend/core/chronicle.py
+++ b/backend/core/chronicle.py
@@ -402,7 +402,11 @@ def _chronicle_game_knowledge(briefing: dict[str, Any]) -> str:
         briefing.get("model_context") if isinstance(briefing.get("model_context"), dict) else {}
     )
     version = str(meta.get("version") or model_context.get("game_version") or "unknown")
-    return build_game_knowledge_prompt(version, purpose="chronicle")
+    return build_game_knowledge_prompt(
+        version,
+        purpose="chronicle",
+        topics=json_dumps(briefing),
+    )
 
 
 class ChronicleGenerator:

--- a/backend/core/chronicle.py
+++ b/backend/core/chronicle.py
@@ -477,6 +477,14 @@ class ChronicleGenerator:
             )
         return self._provider_generator
 
+    def close(self) -> None:
+        """Release provider connections created for this generation request."""
+        close = getattr(self._provider_generator, "close", None)
+        if callable(close):
+            close()
+        self._provider_generator = None
+        self._client = None
+
     def generate_chronicle(
         self,
         session_id: str,

--- a/backend/core/companion.py
+++ b/backend/core/companion.py
@@ -284,6 +284,12 @@ class Companion:
         self.custom_instructions = cleaned or None
         self._build_personality()
 
+    def close(self) -> None:
+        """Release provider connections owned by this companion."""
+        close = getattr(self._advisor_generator, "close", None)
+        if callable(close):
+            close()
+
     def _build_game_context(self) -> dict | None:
         """Build game context dict for version/DLC awareness.
 

--- a/backend/core/companion.py
+++ b/backend/core/companion.py
@@ -51,6 +51,7 @@ from backend.core.model_routing import (
     normalize_model_routing_mode,
 )
 from backend.core.utils import compute_save_hash_from_briefing
+from stellaris_companion.game_knowledge import build_game_knowledge_prompt
 from stellaris_companion.personality import build_optimized_prompt
 from stellaris_save_extractor import SaveExtractor
 
@@ -273,6 +274,7 @@ class Companion:
                 self.situation,
                 game_context,
                 custom_instructions=self.custom_instructions,
+                include_game_knowledge=False,
             )
         except Exception as e:
             logger.warning("Failed to build personality (%s), using fallback", e)
@@ -328,6 +330,17 @@ class Companion:
             "required_dlcs": required_dlcs,
             "missing_dlcs": missing_dlcs,
         }
+
+    def _build_advisor_game_knowledge(self, question: str) -> str:
+        """Select only mechanics relevant to the current advisor question."""
+        game_context = self._build_game_context()
+        if not game_context or not game_context.get("version"):
+            return ""
+        return build_game_knowledge_prompt(
+            str(game_context["version"]),
+            purpose="advisor",
+            topics=question,
+        )
 
     @property
     def is_loaded(self) -> bool:
@@ -1019,6 +1032,9 @@ class Companion:
             "- If a value is missing, say so in the requested language and suggest what to check in-game.\n"
             "- Be a strategic ADVISOR: interpret, prioritize, and recommend next actions.\n"
         )
+        game_knowledge_prompt = self._build_advisor_game_knowledge(cleaned_question)
+        if game_knowledge_prompt:
+            ask_system_prompt += f"\n{game_knowledge_prompt}\n"
         naval_cap_policy_block = self._build_naval_capacity_policy_block(
             question=cleaned_question,
             briefing_json=model_briefing_json,

--- a/backend/electron_main.py
+++ b/backend/electron_main.py
@@ -529,6 +529,7 @@ def main() -> None:
         # Clean up save watcher
         if save_watcher.is_running:
             save_watcher.stop()
+        companion.close()
         logger.info("Server stopped")
 
 

--- a/electron/e2e/advisor-providers.spec.js
+++ b/electron/e2e/advisor-providers.spec.js
@@ -96,8 +96,10 @@ test('configures a compatible Advisor provider and discovers its models', async 
     await page.waitForLoadState('domcontentloaded')
     await page.getByRole('button', { name: /Config/i }).click()
 
-    const providerSelect = page.getByLabel('AI PROVIDER')
-    await expect(providerSelect).toHaveValue('gemini')
+    await expect(page.getByRole('button', { name: /Gemini.*EASIEST SETUP/i })).toHaveAttribute('aria-pressed', 'true')
+    await page.getByRole('button', { name: /Other provider/i }).click()
+    const providerSelect = page.getByLabel('PROVIDER')
+    await expect(providerSelect).toHaveValue('openrouter')
     await providerSelect.selectOption('custom')
     await expect(page.getByText(/extracted game context are sent to this provider/i)).toBeVisible()
 
@@ -130,7 +132,7 @@ test('configures a compatible Advisor provider and discovers its models', async 
     await expect(providerSelect).toHaveValue('custom')
     await expect(modelSelect).toHaveValue('local/strategist-large')
     await page.getByRole('button', { name: 'TEST MODEL' }).click()
-    await expect(page.getByText('ADVISOR + CHRONICLE READY')).toBeVisible()
+    await expect(page.getByText('STRUCTURED RESPONSES SUPPORTED')).toBeVisible()
     await expect(page.getByText(/does not validate campaign-size context/i)).toBeVisible()
     expect(provider.getLastCompletionModel()).toBe('local/strategist-large')
 
@@ -140,7 +142,7 @@ test('configures a compatible Advisor provider and discovers its models', async 
     await reloadedPage.waitForLoadState('domcontentloaded')
     await reloadedPage.getByRole('button', { name: /Config/i }).click()
 
-    await expect(reloadedPage.getByLabel('AI PROVIDER')).toHaveValue('custom')
+    await expect(reloadedPage.getByLabel('PROVIDER')).toHaveValue('custom')
     const sessionOnlyStorage = await reloadedPage
       .getByText(/API keys work for this session but are not saved/i)
       .isVisible()
@@ -187,7 +189,7 @@ test('turns provider failures into actionable Chat recovery', async () => {
     await expect(page.getByText(/ECONNREFUSED/i)).toHaveCount(0)
 
     await page.getByRole('button', { name: 'OPEN PROVIDER SETTINGS' }).click()
-    await expect(page.getByLabel('AI PROVIDER')).toBeVisible()
+    await expect(page.getByText('WHERE SHOULD AI RUN?')).toBeVisible()
   } finally {
     await app.close()
     await backend.stop()
@@ -212,7 +214,7 @@ test('guides an unconfigured Advisor directly to provider settings', async () =>
     await expect(page.getByText(/Ollama is selected but not ready/i)).toBeVisible()
 
     await page.getByRole('button', { name: 'OPEN PROVIDER SETTINGS' }).click()
-    await expect(page.getByLabel('AI PROVIDER')).toBeVisible()
+    await expect(page.getByText('WHERE SHOULD AI RUN?')).toBeVisible()
   } finally {
     await app.close()
     await backend.stop()
@@ -240,7 +242,7 @@ test('keeps existing Chronicle readable while guiding provider setup', async () 
     ).toBeVisible()
 
     await page.getByRole('button', { name: 'OPEN PROVIDER SETTINGS' }).click()
-    await expect(page.getByLabel('AI PROVIDER')).toBeVisible()
+    await expect(page.getByText('WHERE SHOULD AI RUN?')).toBeVisible()
   } finally {
     await app.close()
     await backend.stop()

--- a/electron/e2e/campaign-history.spec.js
+++ b/electron/e2e/campaign-history.spec.js
@@ -88,6 +88,7 @@ test('campaign manager supports bulk cleanup, restore, labels, reset undo, and p
     await expect(dialog.getByText('Clean Test Run')).toBeVisible()
 
     const currentRow = dialog.locator('article').filter({ hasText: 'United Nations of Earth' })
+    await currentRow.getByRole('button', { name: 'More' }).click()
     await currentRow.getByRole('button', { name: 'Clear Chronicle' }).click()
     await currentRow.getByRole('button', { name: 'Confirm clear' }).click()
     await expect(page.getByText('Chronicle cleared. Campaign history was kept.')).toBeVisible()
@@ -97,6 +98,7 @@ test('campaign manager supports bulk cleanup, restore, labels, reset undo, and p
     await cleanRow.getByRole('button', { name: 'Move to Trash' }).click()
     await dialog.getByRole('button', { name: 'Trash (2)' }).click()
     const deleteRow = dialog.locator('article').filter({ hasText: 'Clean Test Run' })
+    await deleteRow.getByRole('button', { name: 'More' }).click()
     await deleteRow.getByRole('button', { name: 'Delete permanently' }).click()
     await deleteRow.getByRole('button', { name: 'Confirm delete' }).click()
     await expect(dialog.getByText('Clean Test Run')).not.toBeVisible()

--- a/electron/main.js
+++ b/electron/main.js
@@ -52,6 +52,7 @@ const {
   discoverAdvisorModels,
   getAdvisorProviderBaseUrl,
   normalizeAdvisorProvider,
+  normalizeProviderBaseUrl,
   testAdvisorModel,
 } = require('./main/advisorProviders')
 
@@ -987,6 +988,10 @@ function getSettingsWithSecrets() {
  * @returns {Object} Result with success status
  */
 function saveSettings(settings) {
+  const normalizedAdvisorBaseUrl = settings.advisorBaseUrl !== undefined
+    ? normalizeProviderBaseUrl(settings.advisorBaseUrl)
+    : null
+
   if (settings.googleApiKey !== undefined && !settings.googleApiKey.includes('...')) {
     setSecret(SECRET_STORE_KEYS.googleApiKey, settings.googleApiKey || null)
   }
@@ -1012,7 +1017,7 @@ function saveSettings(settings) {
   }
 
   if (settings.advisorBaseUrl !== undefined) {
-    store.set('advisorBaseUrl', String(settings.advisorBaseUrl || '').trim())
+    store.set('advisorBaseUrl', normalizedAdvisorBaseUrl)
   }
 
   const nextSaveDir = settings.saveDir !== undefined ? settings.saveDir : settings.savePath

--- a/electron/main/ipc/backend.js
+++ b/electron/main/ipc/backend.js
@@ -7,18 +7,30 @@ function registerBackendIpcHandlers({ ipcMain, validateSender, callBackendApiEnv
     language: typeof getResolvedLanguage === 'function' ? getResolvedLanguage() : 'en',
   })
 
-  ipcMain.handle('backend:health', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  const safeHandle = (channel, handler) => {
+    ipcMain.handle(channel, async (event, ...args) => {
+      try {
+        validateSender(event)
+      } catch (error) {
+        return {
+          ok: false,
+          error: error instanceof Error ? error.message : 'IPC error',
+          code: 'IPC_SENDER_INVALID',
+        }
+      }
+      return await handler(...args)
+    })
+  }
+
+  safeHandle('backend:health', async () => {
     return await callBackendApiEnvelope('/api/health')
   })
 
-  ipcMain.handle('backend:diagnostics', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:diagnostics', async () => {
     return await callBackendApiEnvelope('/api/diagnostics')
   })
 
-  ipcMain.handle('backend:chat', async (event, { message, session_key, model, model_routing_mode }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:chat', async ({ message, session_key, model, model_routing_mode }) => {
     return await callBackendApiEnvelope('/api/chat', {
       method: 'POST',
       body: JSON.stringify(withLanguage({
@@ -30,18 +42,15 @@ function registerBackendIpcHandlers({ ipcMain, validateSender, callBackendApiEnv
     })
   })
 
-  ipcMain.handle('backend:status', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:status', async () => {
     return await callBackendApiEnvelope('/api/status')
   })
 
-  ipcMain.handle('backend:sessions', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:sessions', async () => {
     return await callBackendApiEnvelope('/api/sessions')
   })
 
-  ipcMain.handle('backend:playthroughs', async (event, { include_trashed } = {}) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:playthroughs', async ({ include_trashed } = {}) => {
     const language = typeof getResolvedLanguage === 'function' ? getResolvedLanguage() : 'en'
     const query = new URLSearchParams({
       language,
@@ -50,65 +59,56 @@ function registerBackendIpcHandlers({ ipcMain, validateSender, callBackendApiEnv
     return await callBackendApiEnvelope(`/api/playthroughs?${query.toString()}`)
   })
 
-  ipcMain.handle('backend:cached-chronicle', async (event, { save_id }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:cached-chronicle', async ({ save_id }) => {
     const language = typeof getResolvedLanguage === 'function' ? getResolvedLanguage() : 'en'
     const query = new URLSearchParams({ language })
     return await callBackendApiEnvelope(`/api/playthroughs/${encodeURIComponent(save_id)}/chronicle?${query.toString()}`)
   })
 
-  ipcMain.handle('backend:set-playthrough-label', async (event, { save_id, display_label }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:set-playthrough-label', async ({ save_id, display_label }) => {
     return await callBackendApiEnvelope(`/api/playthroughs/${encodeURIComponent(save_id)}/label`, {
       method: 'POST',
       body: JSON.stringify({ display_label }),
     })
   })
 
-  ipcMain.handle('backend:trash-playthrough', async (event, { save_id }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:trash-playthrough', async ({ save_id }) => {
     return await callBackendApiEnvelope(`/api/playthroughs/${encodeURIComponent(save_id)}/trash`, {
       method: 'POST',
     })
   })
 
-  ipcMain.handle('backend:restore-playthrough', async (event, { save_id }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:restore-playthrough', async ({ save_id }) => {
     return await callBackendApiEnvelope(`/api/playthroughs/${encodeURIComponent(save_id)}/restore`, {
       method: 'POST',
     })
   })
 
-  ipcMain.handle('backend:reset-chronicle', async (event, { save_id }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:reset-chronicle', async ({ save_id }) => {
     return await callBackendApiEnvelope(`/api/playthroughs/${encodeURIComponent(save_id)}/reset-chronicle`, {
       method: 'POST',
       body: JSON.stringify(withLanguage({ confirm: true })),
     })
   })
 
-  ipcMain.handle('backend:undo-chronicle-reset', async (event, { save_id }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:undo-chronicle-reset', async ({ save_id }) => {
     return await callBackendApiEnvelope(`/api/playthroughs/${encodeURIComponent(save_id)}/undo-reset`, {
       method: 'POST',
       body: JSON.stringify(withLanguage()),
     })
   })
 
-  ipcMain.handle('backend:delete-playthrough', async (event, { save_id }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:delete-playthrough', async ({ save_id }) => {
     return await callBackendApiEnvelope(`/api/playthroughs/${encodeURIComponent(save_id)}?confirm=true`, {
       method: 'DELETE',
     })
   })
 
-  ipcMain.handle('backend:history-storage', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:history-storage', async () => {
     return await callBackendApiEnvelope('/api/history/storage')
   })
 
-  ipcMain.handle('backend:session-events', async (event, { session_id, limit }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:session-events', async ({ session_id, limit }) => {
     let url = `/api/sessions/${session_id}/events`
     if (limit) {
       url += `?limit=${limit}`
@@ -116,8 +116,7 @@ function registerBackendIpcHandlers({ ipcMain, validateSender, callBackendApiEnv
     return await callBackendApiEnvelope(url)
   })
 
-  ipcMain.handle('backend:recap', async (event, { session_id, style, model_routing_mode }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:recap', async ({ session_id, style, model_routing_mode }) => {
     return await callBackendApiEnvelope('/api/recap', {
       method: 'POST',
       body: JSON.stringify(withLanguage({
@@ -128,8 +127,7 @@ function registerBackendIpcHandlers({ ipcMain, validateSender, callBackendApiEnv
     })
   })
 
-  ipcMain.handle('backend:chronicle', async (event, { session_id, force_refresh, chapter_only, refresh_mode, model_routing_mode }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:chronicle', async ({ session_id, force_refresh, chapter_only, refresh_mode, model_routing_mode }) => {
     return await callBackendApiEnvelope('/api/chronicle', {
       method: 'POST',
       body: JSON.stringify(withLanguage({
@@ -142,8 +140,7 @@ function registerBackendIpcHandlers({ ipcMain, validateSender, callBackendApiEnv
     })
   })
 
-  ipcMain.handle('backend:regenerate-chapter', async (event, { session_id, chapter_number, confirm, regeneration_instructions, model_routing_mode }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:regenerate-chapter', async ({ session_id, chapter_number, confirm, regeneration_instructions, model_routing_mode }) => {
     return await callBackendApiEnvelope('/api/chronicle/regenerate-chapter', {
       method: 'POST',
       body: JSON.stringify(withLanguage({
@@ -156,33 +153,28 @@ function registerBackendIpcHandlers({ ipcMain, validateSender, callBackendApiEnv
     })
   })
 
-  ipcMain.handle('backend:end-session', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:end-session', async () => {
     return await callBackendApiEnvelope('/api/end-session', {
       method: 'POST',
     })
   })
 
-  ipcMain.handle('backend:get-chronicle-custom', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:get-chronicle-custom', async () => {
     return await callBackendApiEnvelope('/api/chronicle-custom-instructions')
   })
 
-  ipcMain.handle('backend:set-chronicle-custom', async (event, { custom_instructions }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:set-chronicle-custom', async ({ custom_instructions }) => {
     return await callBackendApiEnvelope('/api/chronicle-custom-instructions', {
       method: 'POST',
       body: JSON.stringify({ custom_instructions }),
     })
   })
 
-  ipcMain.handle('backend:get-session-advisor-custom', async (event) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:get-session-advisor-custom', async () => {
     return await callBackendApiEnvelope('/api/session-advisor-custom')
   })
 
-  ipcMain.handle('backend:set-session-advisor-custom', async (event, { custom_instructions }) => {
-    try { validateSender(event) } catch (e) { return { ok: false, error: e instanceof Error ? e.message : 'IPC error', code: 'IPC_SENDER_INVALID' } }
+  safeHandle('backend:set-session-advisor-custom', async ({ custom_instructions }) => {
     return await callBackendApiEnvelope('/api/session-advisor-custom', {
       method: 'POST',
       body: JSON.stringify({ custom_instructions }),

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -71,9 +71,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -273,9 +273,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -996,9 +996,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1521,9 +1521,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1960,9 +1960,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2011,9 +2011,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2203,9 +2203,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2530,9 +2530,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellaris-companion",
-  "version": "0.9.0-beta.4",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellaris-companion",
-      "version": "0.9.0-beta.4",
+      "version": "1.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "electron-store": "^8.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -16,6 +16,7 @@
     "build:renderer": "cd renderer && npm run build",
     "build:electron": "electron-builder",
     "build:mcpb": "python3 ../scripts/package_mcpb.py",
+    "test": "node --test test/*.test.js",
     "test:e2e": "npm run build:renderer && playwright test",
     "test:e2e:headed": "npm run build:renderer && playwright test --headed",
     "test:chronicle-publishing": "node --test test/chronicle-publishing.test.js",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellaris-companion",
-  "version": "0.9.0-beta.4",
+  "version": "1.0.0-beta.1",
   "description": "Desktop companion app for Stellaris - AI-powered strategic advisor",
   "main": "main.js",
   "author": "Stellaris Companion",

--- a/electron/release-notes.md
+++ b/electron/release-notes.md
@@ -1,4 +1,9 @@
-- Added Campaign History tools to rename, hide, restore, or remove individual campaigns.
-- Made empty restart cleanup faster with search and one-click selection.
-- Existing Chronicles remain intact through automatic upgrades, with backup and undo protection.
-- Thanks to **duelingThoughts** for bringing this to my attention.
+**The largest Stellaris Companion update yet.**
+
+- Added support for Gemini, Ollama, LM Studio, OpenRouter, and other compatible AI providers.
+- Added Campaign History with search, rename, trash, restore, cleanup, and protected Chronicle resets.
+- Improved Advisor and Chronicle accuracy with save-grounded evidence and verified Stellaris mechanics.
+- Simplified provider setup and Chronicle refresh controls.
+- Improved performance, dependency security, and release reliability.
+
+This is a major beta release. If something feels unclear or unreliable, please report it so we can polish the stable 1.0 release.

--- a/electron/renderer/components/CampaignHistoryDialog.tsx
+++ b/electron/renderer/components/CampaignHistoryDialog.tsx
@@ -431,33 +431,39 @@ function CampaignHistoryDialog({
                                 <ActionButton onClick={() => { setEditingId(playthrough.save_id); setLabel(playthrough.display_label || '') }} disabled={isWorking}>
                                   {t('chronicle.history.rename')}
                                 </ActionButton>
-                                {playthrough.can_undo_reset ? (
-                                  <ActionButton onClick={() => void handleUndoReset(playthrough)} disabled={isWorking}>
-                                    {t('chronicle.history.undoReset')}
-                                  </ActionButton>
-                                ) : playthrough.has_chronicle ? (
-                                  <ActionButton onClick={() => void handleReset(playthrough)} disabled={isWorking} tone="warning">
-                                    {confirmResetId === playthrough.save_id ? t('chronicle.history.confirmReset') : t('chronicle.history.reset')}
-                                  </ActionButton>
-                                ) : null}
                                 <ActionButton onClick={() => void handleTrash(playthrough)} disabled={isWorking || playthrough.is_current} tone="warning" title={playthrough.is_current ? t('chronicle.history.currentProtected') : undefined}>
                                   {t('chronicle.history.moveToTrash')}
                                 </ActionButton>
+                                {(playthrough.can_undo_reset || playthrough.has_chronicle) && (
+                                  <OverflowActions label={t('chronicle.history.moreActions')}>
+                                    {playthrough.can_undo_reset ? (
+                                      <ActionButton onClick={() => void handleUndoReset(playthrough)} disabled={isWorking}>
+                                        {t('chronicle.history.undoReset')}
+                                      </ActionButton>
+                                    ) : (
+                                      <ActionButton onClick={() => void handleReset(playthrough)} disabled={isWorking} tone="warning">
+                                        {confirmResetId === playthrough.save_id ? t('chronicle.history.confirmReset') : t('chronicle.history.reset')}
+                                      </ActionButton>
+                                    )}
+                                  </OverflowActions>
+                                )}
                               </>
                             ) : (
                               <>
                                 <ActionButton onClick={() => void handleRestore(playthrough)} disabled={isWorking}>
                                   {t('chronicle.history.restore')}
                                 </ActionButton>
-                                <ActionButton onClick={() => void handleDelete(playthrough)} disabled={isWorking} tone="danger">
-                                  {publication?.state === 'published'
-                                    ? (confirmDeleteId === playthrough.save_id
-                                      ? t('chronicle.history.confirmDeleteLocal')
-                                      : t('chronicle.history.deleteLocal'))
-                                    : (confirmDeleteId === playthrough.save_id
-                                      ? t('chronicle.history.confirmDelete')
-                                      : t('chronicle.history.delete'))}
-                                </ActionButton>
+                                <OverflowActions label={t('chronicle.history.moreActions')}>
+                                  <ActionButton onClick={() => void handleDelete(playthrough)} disabled={isWorking} tone="danger">
+                                    {publication?.state === 'published'
+                                      ? (confirmDeleteId === playthrough.save_id
+                                        ? t('chronicle.history.confirmDeleteLocal')
+                                        : t('chronicle.history.deleteLocal'))
+                                      : (confirmDeleteId === playthrough.save_id
+                                        ? t('chronicle.history.confirmDelete')
+                                        : t('chronicle.history.delete'))}
+                                  </ActionButton>
+                                </OverflowActions>
                               </>
                             )}
                           </div>
@@ -550,6 +556,29 @@ function ActionButton({
     >
       {children}
     </button>
+  )
+}
+
+function OverflowActions({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <details className="group relative">
+      <summary
+        role="button"
+        aria-label={label}
+        className="cursor-pointer list-none rounded border border-border px-3 py-1.5 text-[10px] uppercase tracking-wider text-text-secondary hover:border-accent-cyan/40 hover:text-accent-cyan"
+      >
+        {label}
+      </summary>
+      <div className="absolute right-0 z-10 mt-2 flex min-w-max justify-end rounded border border-border bg-bg-primary p-2 shadow-xl">
+        {children}
+      </div>
+    </details>
   )
 }
 

--- a/electron/renderer/components/settings/AdvisorProviderChooser.tsx
+++ b/electron/renderer/components/settings/AdvisorProviderChooser.tsx
@@ -1,0 +1,83 @@
+import { useTranslation } from 'react-i18next'
+import type { AdvisorProvider } from '../../hooks/useSettings'
+import { HUDSelect } from '../hud/HUDForm'
+import { HUDLabel, HUDMicro } from '../hud/HUDText'
+
+type ProviderGroup = 'gemini' | 'local' | 'other'
+
+interface AdvisorProviderChooserProps {
+  provider: AdvisorProvider
+  onChange: (provider: AdvisorProvider) => void
+}
+
+const LOCAL_PROVIDERS: AdvisorProvider[] = ['ollama', 'lm_studio']
+const OTHER_PROVIDERS: AdvisorProvider[] = ['openrouter', 'custom']
+
+function providerGroup(provider: AdvisorProvider): ProviderGroup {
+  if (provider === 'gemini') return 'gemini'
+  if (LOCAL_PROVIDERS.includes(provider)) return 'local'
+  return OTHER_PROVIDERS.includes(provider) ? 'other' : 'gemini'
+}
+
+export function AdvisorProviderChooser({ provider, onChange }: AdvisorProviderChooserProps) {
+  const { t } = useTranslation()
+  const selectedGroup = providerGroup(provider)
+  const groups: ProviderGroup[] = ['gemini', 'local', 'other']
+
+  const chooseGroup = (group: ProviderGroup) => {
+    if (group === selectedGroup) return
+    if (group === 'gemini') onChange('gemini')
+    if (group === 'local') onChange('ollama')
+    if (group === 'other') onChange('openrouter')
+  }
+
+  const providerOptions = selectedGroup === 'local'
+    ? [
+      { value: 'ollama', label: 'Ollama' },
+      { value: 'lm_studio', label: 'LM Studio' },
+    ]
+    : [
+      { value: 'openrouter', label: 'OpenRouter' },
+      { value: 'custom', label: t('settings.advisor.providers.custom') },
+    ]
+
+  return (
+    <div className="space-y-3">
+      <HUDLabel>{t('settings.advisor.providerChoiceLabel')}</HUDLabel>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {groups.map(group => {
+          const selected = selectedGroup === group
+          return (
+            <button
+              key={group}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => chooseGroup(group)}
+              className={`rounded-sm border px-3 py-2 text-left transition-all duration-200 ${
+                selected
+                  ? 'border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan'
+                  : 'border-white/10 bg-black/20 text-text-secondary hover:border-white/20 hover:bg-white/5 hover:text-text-primary'
+              }`}
+            >
+              <div className="font-display text-[11px] uppercase tracking-[0.16em]">
+                {t(`settings.advisor.providerGroups.${group}`)}
+              </div>
+              <HUDMicro className="mt-1 block text-[9px] text-white/40">
+                {t(`settings.advisor.providerGroups.${group}Tag`)}
+              </HUDMicro>
+            </button>
+          )
+        })}
+      </div>
+
+      {selectedGroup !== 'gemini' && (
+        <HUDSelect
+          label={t(`settings.advisor.${selectedGroup}ProviderLabel`)}
+          value={provider}
+          onChange={event => onChange(event.target.value as AdvisorProvider)}
+          options={providerOptions}
+        />
+      )}
+    </div>
+  )
+}

--- a/electron/renderer/components/settings/ChronicleRefreshControl.tsx
+++ b/electron/renderer/components/settings/ChronicleRefreshControl.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next'
+import type { ChronicleRefreshMode } from '../../hooks/useSettings'
+import { HUDLabel, HUDMicro } from '../hud/HUDText'
+
+interface ChronicleRefreshControlProps {
+  mode: ChronicleRefreshMode
+  saving: boolean
+  onChange: (mode: ChronicleRefreshMode) => void
+}
+
+export function ChronicleRefreshControl({
+  mode,
+  saving,
+  onChange,
+}: ChronicleRefreshControlProps) {
+  const { t } = useTranslation()
+  const options: ChronicleRefreshMode[] = ['balanced', 'enhanced']
+
+  return (
+    <div className="space-y-3 border-t border-white/10 pt-4">
+      <div className="flex items-center justify-between gap-3">
+        <HUDLabel>{t('settings.chronicleRefresh.label')}</HUDLabel>
+        {saving && <HUDMicro className="text-right">{t('common.applying')}</HUDMicro>}
+      </div>
+      <div className="grid grid-cols-2 gap-2 rounded-sm border border-white/10 bg-black/20 p-1">
+        {options.map(option => {
+          const selected = mode === option
+          return (
+            <button
+              key={option}
+              type="button"
+              disabled={saving}
+              aria-pressed={selected}
+              aria-label={t('settings.chronicleRefresh.aria', {
+                mode: t(`settings.chronicleRefresh.${option}`),
+              })}
+              onClick={() => onChange(option)}
+              className={`rounded-sm px-3 py-2 text-left transition-all duration-200 ${
+                selected
+                  ? 'border border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan'
+                  : 'border border-transparent text-text-secondary hover:border-white/15 hover:bg-white/5'
+              } disabled:cursor-not-allowed disabled:opacity-50`}
+            >
+              <div className="font-display text-[11px] uppercase tracking-[0.18em]">
+                {t(`settings.chronicleRefresh.${option}`)}
+              </div>
+              <div className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">
+                {t(`settings.chronicleRefresh.${option}Tag`)}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+      <HUDMicro className="block normal-case tracking-[0.02em] text-white/45">
+        {t(`settings.chronicleRefresh.${mode}Help`)}
+      </HUDMicro>
+    </div>
+  )
+}

--- a/electron/renderer/i18n/locales/en/common.json
+++ b/electron/renderer/i18n/locales/en/common.json
@@ -216,6 +216,7 @@
       "chapters_one": "{{count}} chapter",
       "chapters_other": "{{count}} chapters",
       "moreDetails": "More details",
+      "moreActions": "More",
       "selectCampaign": "Select {{name}}",
       "labelPlaceholder": "Campaign label",
       "rename": "Rename",

--- a/electron/renderer/i18n/locales/en/common.json
+++ b/electron/renderer/i18n/locales/en/common.json
@@ -367,6 +367,17 @@
     },
     "advisor": {
       "providerLabel": "AI PROVIDER",
+      "providerChoiceLabel": "WHERE SHOULD AI RUN?",
+      "localProviderLabel": "LOCAL APP",
+      "otherProviderLabel": "PROVIDER",
+      "providerGroups": {
+        "gemini": "Gemini",
+        "geminiTag": "EASIEST SETUP",
+        "local": "Local / private",
+        "localTag": "RUNS ON THIS DEVICE",
+        "other": "Other provider",
+        "otherTag": "HOSTED OR CUSTOM"
+      },
       "apiKeyLabel": "OPENROUTER API KEY",
       "optionalApiKeyLabel": "API KEY",
       "baseUrlLabel": "SERVER URL",
@@ -388,8 +399,8 @@
       "connectionError": "Could not check this provider.",
       "testModel": "TEST MODEL",
       "testingModel": "TESTING MODEL...",
-      "modelReady": "ADVISOR + CHRONICLE READY",
-      "modelReadyPromptJson": "ADVISOR + CHRONICLE READY // COMPATIBILITY MODE",
+      "modelReady": "STRUCTURED RESPONSES SUPPORTED",
+      "modelReadyPromptJson": "STRUCTURED RESPONSES SUPPORTED // COMPATIBILITY MODE",
       "modelAdvisorOnly": "ADVISOR READY // CHRONICLE NOT COMPATIBLE",
       "modelTestError": "The selected model could not complete the structured output test.",
       "modelTestPrivacy": "The test sends no campaign data and does not validate campaign-size context.",

--- a/electron/renderer/package-lock.json
+++ b/electron/renderer/package-lock.json
@@ -18,12 +18,12 @@
       "devDependencies": {
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
-        "@vitejs/plugin-react": "^4.2.0",
+        "@vitejs/plugin-react": "^6.0.5",
         "autoprefixer": "^10.4.23",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.3.0",
-        "vite": "^5.0.0"
+        "vite": "^8.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -39,240 +39,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.6"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -280,445 +46,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -729,17 +56,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -809,31 +125,20 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
-      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
-      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
       "cpu": [
         "arm64"
       ],
@@ -842,12 +147,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
-      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
       "cpu": [
         "arm64"
       ],
@@ -856,12 +164,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
-      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
       "cpu": [
         "x64"
       ],
@@ -870,26 +181,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
-      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
-      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
       "cpu": [
         "x64"
       ],
@@ -898,12 +198,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
-      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
       "cpu": [
         "arm"
       ],
@@ -912,26 +215,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
-      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
-      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
       "cpu": [
         "arm64"
       ],
@@ -940,12 +232,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
-      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
       ],
@@ -954,40 +249,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
-      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
-      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
-      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
       "cpu": [
         "ppc64"
       ],
@@ -996,54 +266,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
-      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
-      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
-      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
-      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
       ],
@@ -1052,12 +283,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
-      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
       "cpu": [
         "x64"
       ],
@@ -1066,12 +300,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
-      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
       ],
@@ -1080,26 +317,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
-      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
-      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
       "cpu": [
         "arm64"
       ],
@@ -1108,12 +334,15 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
-      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
       "cpu": [
         "arm64"
       ],
@@ -1122,26 +351,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
-      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
-      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
       "cpu": [
         "x64"
       ],
@@ -1150,66 +368,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
-      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -1221,9 +390,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -1270,6 +439,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1298,24 +468,29 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/any-promise": {
@@ -1449,6 +624,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1602,13 +778,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1667,6 +836,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -1700,45 +879,6 @@
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
-      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1885,16 +1025,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1999,6 +1129,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -2138,6 +1269,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2148,30 +1280,265 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=6"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -2214,16 +1581,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -2879,9 +2236,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2974,9 +2331,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3007,9 +2364,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3026,8 +2383,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3205,6 +2563,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3217,6 +2576,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3277,16 +2637,6 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
-      }
-    },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/read-cache": {
@@ -3377,49 +2727,37 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
-      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.55.1",
-        "@rollup/rollup-android-arm64": "4.55.1",
-        "@rollup/rollup-darwin-arm64": "4.55.1",
-        "@rollup/rollup-darwin-x64": "4.55.1",
-        "@rollup/rollup-freebsd-arm64": "4.55.1",
-        "@rollup/rollup-freebsd-x64": "4.55.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
-        "@rollup/rollup-linux-arm64-musl": "4.55.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
-        "@rollup/rollup-linux-loong64-musl": "4.55.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
-        "@rollup/rollup-linux-x64-gnu": "4.55.1",
-        "@rollup/rollup-linux-x64-musl": "4.55.1",
-        "@rollup/rollup-openbsd-x64": "4.55.1",
-        "@rollup/rollup-openharmony-arm64": "4.55.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
-        "@rollup/rollup-win32-x64-gnu": "4.55.1",
-        "@rollup/rollup-win32-x64-msvc": "4.55.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
     "node_modules/run-parallel": {
@@ -3453,16 +2791,6 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/source-map-js": {
@@ -3615,14 +2943,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3650,11 +2978,12 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3714,6 +3043,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3885,21 +3215,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -3908,23 +3241,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -3941,7 +3284,26 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/void-elements": {
@@ -3952,13 +3314,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/electron/renderer/package.json
+++ b/electron/renderer/package.json
@@ -19,11 +19,11 @@
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@vitejs/plugin-react": "^4.2.0",
+    "@vitejs/plugin-react": "^6.0.5",
     "autoprefixer": "^10.4.23",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^8.2.1"
   }
 }

--- a/electron/renderer/pages/ChroniclePage.tsx
+++ b/electron/renderer/pages/ChroniclePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { lazy, Suspense, useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
@@ -6,7 +6,6 @@ import ChronicleChapterList from '../components/ChronicleChapterList'
 import ChronicleContent from '../components/ChronicleContent'
 import ChronicleInfoPanel from '../components/ChronicleInfoPanel'
 import ChroniclePublishDialog from '../components/ChroniclePublishDialog'
-import CampaignHistoryDialog from '../components/CampaignHistoryDialog'
 import { useBackend, ChronicleResponse, type Playthrough } from '../hooks/useBackend'
 import { generateChronicleHtml } from '../lib/chronicleExport'
 import {
@@ -16,6 +15,8 @@ import {
 } from '../hooks/useSettings'
 import { HUDMicro } from '../components/hud/HUDText'
 import { HUDButton } from '../components/hud/HUDButton'
+
+const CampaignHistoryDialog = lazy(() => import('../components/CampaignHistoryDialog'))
 
 interface SaveInfo {
   save_id: string
@@ -1003,12 +1004,16 @@ function ChroniclePage({
         empireName={empireName}
         chronicle={chronicle}
       />
-      <CampaignHistoryDialog
-        isOpen={historyDialogOpen}
-        onClose={() => setHistoryDialogOpen(false)}
-        playthroughs={playthroughs}
-        onChanged={handleHistoryChanged}
-      />
+      {historyDialogOpen && (
+        <Suspense fallback={null}>
+          <CampaignHistoryDialog
+            isOpen
+            onClose={() => setHistoryDialogOpen(false)}
+            playthroughs={playthroughs}
+            onChanged={handleHistoryChanged}
+          />
+        </Suspense>
+      )}
     </div>
   )
 }

--- a/electron/renderer/pages/SettingsPage.tsx
+++ b/electron/renderer/pages/SettingsPage.tsx
@@ -31,6 +31,8 @@ import { HUDInput } from '../components/hud/HUDInput'
 import { HUDButton } from '../components/hud/HUDButton'
 import { HUDSelect } from '../components/hud/HUDForm'
 import { useToast } from '../components/Toast'
+import { AdvisorProviderChooser } from '../components/settings/AdvisorProviderChooser'
+import { ChronicleRefreshControl } from '../components/settings/ChronicleRefreshControl'
 import type { McpRelayHealthResult, McpRelayStatus } from '../global'
 import type { HistoryStorageResponse } from '../hooks/useBackend'
 
@@ -73,14 +75,6 @@ const UI_THEME_LABELS: Record<UiTheme, string> = {
   'tactica-green': 'Tactica Green',
   'command-amber': 'Command Amber',
 }
-
-const ADVISOR_PROVIDER_OPTIONS: { value: AdvisorProvider; label: string }[] = [
-  { value: 'gemini', label: 'Gemini' },
-  { value: 'ollama', label: 'Ollama' },
-  { value: 'lm_studio', label: 'LM Studio' },
-  { value: 'openrouter', label: 'OpenRouter' },
-  { value: 'custom', label: 'Custom (OpenAI-compatible)' },
-]
 
 const ADVISOR_PROVIDER_DEFAULT_URLS: Partial<Record<AdvisorProvider, string>> = {
   ollama: 'http://127.0.0.1:11434/v1',
@@ -786,12 +780,6 @@ function SettingsPage({
     label: t(`languages.${option.value}`),
   }))
 
-  const chronicleModeLabel = (mode: ChronicleRefreshMode) =>
-    t(`settings.chronicleRefresh.${mode}`)
-
-  const chronicleModeHelper = (mode: ChronicleRefreshMode) =>
-    t(`settings.chronicleRefresh.${mode}Help`)
-
   const modelRoutingLabel = (mode: ModelRoutingMode) =>
     t(`settings.modelRouting.${mode === 'quality_first' ? 'qualityFirst' : 'conserve'}`)
 
@@ -971,11 +959,9 @@ function SettingsPage({
                     <HUDSectionTitle number="01">{t('settings.sections.intelligence')}</HUDSectionTitle>
                     <HUDPanel decoration="tech" title={t('settings.panels.advisorAccess')} quiet>
                         <div className="space-y-4 pt-2">
-                             <HUDSelect
-                                label={t('settings.advisor.providerLabel')}
-                                value={advisorProvider}
-                                onChange={(e) => handleAdvisorProviderChange(e.target.value)}
-                                options={ADVISOR_PROVIDER_OPTIONS}
+                             <AdvisorProviderChooser
+                               provider={advisorProvider}
+                               onChange={handleAdvisorProviderChange}
                              />
                              {settings?.secretStorageAvailable === false && (
                                <HUDMicro className="block border-l border-accent-yellow/50 pl-2 normal-case tracking-[0.02em] text-accent-yellow/75">
@@ -1314,89 +1300,15 @@ function SettingsPage({
                                        </HUDMicro>
                                      </div>
 
-                                     <div className="space-y-3">
-                                       <div className="flex items-center justify-between gap-3">
-                                         <HUDLabel>{t('settings.chronicleRefresh.label')}</HUDLabel>
-                                         {chronicleRefreshModeSaving && (
-                                           <HUDMicro className="text-right">{t('common.applying')}</HUDMicro>
-                                         )}
-                                       </div>
-
-                                       <div className="grid grid-cols-2 gap-2 rounded-sm border border-white/10 bg-black/20 p-1">
-                                         {(['balanced', 'enhanced'] as const).map((mode) => {
-                                           const isSelected = chronicleRefreshMode === mode
-                                           return (
-                                             <button
-                                               key={mode}
-                                               type="button"
-                                               disabled={chronicleRefreshModeSaving}
-                                               aria-pressed={isSelected}
-                                               aria-label={t('settings.chronicleRefresh.aria', { mode: chronicleModeLabel(mode) })}
-                                               onClick={() => void handleChronicleRefreshModeChange(mode)}
-                                               className={`relative rounded-sm px-3 py-2 text-left transition-all duration-200 ${
-                                                 isSelected
-                                                   ? 'border border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan'
-                                                   : 'border border-transparent bg-transparent text-text-secondary hover:border-white/15 hover:bg-white/5 hover:text-text-primary'
-                                               } disabled:opacity-50 disabled:cursor-not-allowed`}
-                                             >
-                                               <div className="font-display text-[11px] uppercase tracking-[0.18em]">
-                                                 {chronicleModeLabel(mode)}
-                                               </div>
-                                               <div className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">
-                                                 {mode === 'balanced' ? t('settings.chronicleRefresh.balancedTag') : t('settings.chronicleRefresh.enhancedTag')}
-                                               </div>
-                                             </button>
-                                           )
-                                         })}
-                                       </div>
-
-                                       <HUDMicro className="block text-[10px] leading-relaxed text-white/45 normal-case tracking-[0.02em]">
-                                         {chronicleModeHelper(chronicleRefreshMode)}
-                                       </HUDMicro>
-                                     </div>
                                    </div>
                                  </details>
                              </div>
                              )}
-                             {advisorProvider !== 'gemini' && (
-                               <div className="space-y-3 border-t border-white/10 pt-4">
-                                 <div className="flex items-center justify-between gap-3">
-                                   <HUDLabel>{t('settings.chronicleRefresh.label')}</HUDLabel>
-                                   {chronicleRefreshModeSaving && (
-                                     <HUDMicro className="text-right">{t('common.applying')}</HUDMicro>
-                                   )}
-                                 </div>
-                                 <div className="grid grid-cols-2 gap-2 rounded-sm border border-white/10 bg-black/20 p-1">
-                                   {(['balanced', 'enhanced'] as const).map((mode) => {
-                                     const isSelected = chronicleRefreshMode === mode
-                                     return (
-                                       <button
-                                         key={mode}
-                                         type="button"
-                                         disabled={chronicleRefreshModeSaving}
-                                         aria-pressed={isSelected}
-                                         onClick={() => void handleChronicleRefreshModeChange(mode)}
-                                         className={`rounded-sm px-3 py-2 text-left transition-all duration-200 ${
-                                           isSelected
-                                             ? 'border border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan'
-                                             : 'border border-transparent text-text-secondary hover:border-white/15 hover:bg-white/5'
-                                         } disabled:cursor-not-allowed disabled:opacity-50`}
-                                       >
-                                         <div className="font-display text-[11px] uppercase tracking-[0.18em]">
-                                           {chronicleModeLabel(mode)}
-                                         </div>
-                                         <div className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">
-                                           {mode === 'balanced' ? t('settings.chronicleRefresh.balancedTag') : t('settings.chronicleRefresh.enhancedTag')}
-                                         </div>
-                                       </button>
-                                     )
-                                   })}
-                                 </div>
-                                 <HUDMicro className="block normal-case tracking-[0.02em] text-white/45">
-                                   {chronicleModeHelper(chronicleRefreshMode)}
-                                 </HUDMicro>
-                               </div>
-                             )}
+                             <ChronicleRefreshControl
+                               mode={chronicleRefreshMode}
+                               saving={chronicleRefreshModeSaving}
+                               onChange={(mode) => void handleChronicleRefreshModeChange(mode)}
+                             />
                         </div>
                     </HUDPanel>
                 </section>

--- a/electron/test/campaign-history-ipc.test.js
+++ b/electron/test/campaign-history-ipc.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict')
 const test = require('node:test')
 const { registerBackendIpcHandlers } = require('../main/ipc/backend')
 
-function createHarness() {
+function createHarness({ validateSender = () => {} } = {}) {
   const handlers = new Map()
   const calls = []
   registerBackendIpcHandlers({
@@ -11,7 +11,7 @@ function createHarness() {
         handlers.set(channel, handler)
       },
     },
-    validateSender: () => {},
+    validateSender,
     getResolvedLanguage: () => 'de',
     callBackendApiEnvelope: async (url, options) => {
       calls.push({ url, options })
@@ -21,6 +21,23 @@ function createHarness() {
   const invoke = (channel, payload) => handlers.get(channel)({}, payload)
   return { calls, invoke }
 }
+
+test('backend IPC rejects an invalid sender before calling the backend', async () => {
+  const { calls, invoke } = createHarness({
+    validateSender: () => {
+      throw new Error('Untrusted renderer')
+    },
+  })
+
+  const result = await invoke('backend:health')
+
+  assert.deepEqual(result, {
+    ok: false,
+    error: 'Untrusted renderer',
+    code: 'IPC_SENDER_INVALID',
+  })
+  assert.equal(calls.length, 0)
+})
 
 test('campaign history IPC uses language-scoped, URL-safe backend routes', async () => {
   const { calls, invoke } = createHarness()

--- a/electron/test/settings-locales.test.js
+++ b/electron/test/settings-locales.test.js
@@ -19,3 +19,14 @@ test('ships complete update-channel and protected-storage copy in every locale',
     assert.ok(settings?.updateChannel?.betaWarning, `${locale}: missing Beta warning`)
   }
 })
+
+test('keeps provider setup simple without overstating the connection probe', () => {
+  const messages = JSON.parse(fs.readFileSync(path.join(localesDir, 'en', 'common.json'), 'utf8'))
+  const advisor = messages.settings.advisor
+
+  assert.ok(advisor.providerGroups.gemini)
+  assert.ok(advisor.providerGroups.local)
+  assert.ok(advisor.providerGroups.other)
+  assert.match(advisor.modelReady, /structured responses supported/i)
+  assert.doesNotMatch(advisor.modelReady, /advisor.*chronicle ready/i)
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellaris-companion"
-version = "0.9.0-beta.4"
+version = "1.0.0-beta.1"
 description = "AI-powered strategic advisor for Stellaris with configurable model providers"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "google-genai>=1.0.0",
     # Keep macOS PyInstaller bundles on pyca's statically-linked universal wheel.
-    "cryptography==48.0.1",
+    "cryptography==50.0.0",
     "python-dotenv>=1.0.0",
     "watchdog>=3.0",
     "fastapi>=0.100.0",

--- a/stellaris-backend.spec
+++ b/stellaris-backend.spec
@@ -85,9 +85,7 @@ a = Analysis(
         'google.genai',
         'google.genai._api_client',
         'google.genai.types',
-        'google.api_core',
         'google.auth',
-        'google.protobuf',
         # FastAPI and dependencies
         'fastapi',
         'starlette',

--- a/stellaris-parser/src/edge_cases.rs
+++ b/stellaris-parser/src/edge_cases.rs
@@ -304,7 +304,7 @@ with_empty={
         let parsed: HashMap<String, Value> =
             from_utf8_slice(clausewitz_data).expect("Failed to parse empty blocks");
 
-        assert!(parsed.get("empty").is_some(), "empty should exist");
+        assert!(parsed.contains_key("empty"), "empty should exist");
 
         let with_empty = parsed.get("with_empty").expect("with_empty should exist");
         assert!(with_empty.get("nested").is_some(), "nested should exist");

--- a/stellaris_companion/game_knowledge.py
+++ b/stellaris_companion/game_knowledge.py
@@ -28,6 +28,38 @@ DEFAULT_PATCHES_DIR = _find_default_patches_dir()
 DEFAULT_SNAPSHOTS_DIR = DEFAULT_PATCHES_DIR / "snapshots"
 
 _VERSION_PATTERN = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
+_MARKDOWN_SECTION_PATTERN = re.compile(r"(?m)^(#{1,3})\s+(.+?)\s*$")
+_SEARCH_ALIASES: dict[str, tuple[str, ...]] = {
+    "pop": ("population", "workforce", "colony"),
+    "growth": ("population", "workforce", "colony"),
+    "job": ("population", "workforce"),
+    "district": ("planet", "development", "production"),
+    "building": ("planet", "development", "production"),
+    "resource": ("economy", "trade", "production", "reserve"),
+    "energy": ("economy", "production", "reserve"),
+    "mineral": ("economy", "production", "reserve"),
+    "alloy": ("economy", "production"),
+    "food": ("economy", "production"),
+    "technology": ("research", "science", "focus"),
+    "tech": ("research", "science", "focus"),
+    "scientist": ("research", "science"),
+    "ship": ("naval", "fleet", "starbase"),
+    "anchorage": ("naval", "fleet", "starbase"),
+    "psi": ("psionic", "shroud"),
+    "gaia": ("infernal", "hot"),
+    "battle": ("combat", "war", "threat"),
+    "army": ("combat", "war", "military"),
+    "invasion": ("combat", "war", "military"),
+    "occupation": ("combat", "war"),
+    "arkship": ("nomad", "logistics"),
+    "waystation": ("nomad", "logistics", "contract"),
+    "wayline": ("nomad", "logistics"),
+    "cargo": ("reserve", "economy", "logistics"),
+    "abundance": ("reserve", "economy"),
+    "astral": ("automation", "reliability", "science"),
+    "rift": ("automation", "reliability", "science"),
+    "automated": ("automation", "reliability"),
+}
 
 KnowledgeStatus = Literal["exact", "partial", "unsupported_newer", "unavailable"]
 KnowledgePurpose = Literal["advisor", "chronicle"]
@@ -95,6 +127,67 @@ def _load_file(version: str, directory: Path) -> str | None:
         return clean_knowledge_content(path.read_text(encoding="utf-8"))
     except OSError:
         return None
+
+
+def _search_terms(text: str) -> set[str]:
+    terms = set(re.findall(r"[a-z0-9]+", text.lower()))
+    singular_terms = {
+        f"{term[:-3]}y" if term.endswith("ies") else term[:-1]
+        for term in terms
+        if len(term) > 3 and term.endswith(("ies", "s"))
+    }
+    terms.update(singular_terms)
+    for term in tuple(terms):
+        terms.update(_SEARCH_ALIASES.get(term, ()))
+    return terms
+
+
+def _select_relevant_sections(content: str, topics: str, *, limit: int) -> str:
+    """Keep safety baselines plus the few mechanics sections relevant to a request."""
+    headings = list(_MARKDOWN_SECTION_PATTERN.finditer(content))
+    if not headings:
+        return content
+
+    topic_terms = _search_terms(topics)
+    selected: set[int] = set()
+    candidates: list[tuple[int, int, int, set[str]]] = []
+    document_index = -1
+
+    for index, match in enumerate(headings):
+        if match.group(1) == "#":
+            document_index += 1
+        title = match.group(2).strip()
+        normalized_title = title.lower()
+        if (
+            "critical 4.x baseline" in normalized_title
+            or "interpretation guardrails" in normalized_title
+        ):
+            selected.add(index)
+            continue
+
+        matched_terms = topic_terms & _search_terms(title)
+        score = len(matched_terms)
+        if score:
+            candidates.append((score, document_index, index, matched_terms))
+
+    # A newer overlay with the same topic takes precedence over an older snapshot.
+    current_candidates = [
+        candidate
+        for candidate in candidates
+        if not any(
+            newer_document > candidate[1] and len(candidate[3] & newer_terms) >= 2
+            for _, newer_document, _, newer_terms in candidates
+        )
+    ]
+    current_candidates.sort(key=lambda item: (-item[0], -item[1], -item[2]))
+    selected.update(index for _, _, index, _ in current_candidates[:limit])
+
+    sections: list[str] = []
+    for index in sorted(selected):
+        start = headings[index].start()
+        end = headings[index + 1].start() if index + 1 < len(headings) else len(content)
+        sections.append(content[start:end].strip())
+    return "\n\n".join(sections)
 
 
 def load_game_knowledge(
@@ -192,6 +285,8 @@ def build_game_knowledge_prompt(
     version: str,
     *,
     purpose: KnowledgePurpose,
+    topics: str | None = None,
+    max_topic_sections: int = 3,
     patches_dir: Path = DEFAULT_PATCHES_DIR,
     snapshots_dir: Path = DEFAULT_SNAPSHOTS_DIR,
 ) -> str:
@@ -225,17 +320,25 @@ def build_game_knowledge_prompt(
         purpose_rule,
     ]
 
-    if knowledge.content and knowledge.status == "exact":
+    knowledge_content = knowledge.content
+    if knowledge_content and topics is not None:
+        knowledge_content = _select_relevant_sections(
+            knowledge_content,
+            topics,
+            limit=max(0, max_topic_sections),
+        )
+
+    if knowledge_content and knowledge.status == "exact":
         lines.extend(
             [
                 "",
                 f"Verified mechanics for {version}:",
                 "Treat these as the current baseline. Do not discuss patches or changes.",
                 "",
-                knowledge.content,
+                knowledge_content,
             ]
         )
-    elif knowledge.content:
+    elif knowledge_content:
         lines.extend(
             [
                 "",
@@ -243,7 +346,16 @@ def build_game_knowledge_prompt(
                 f"The campaign reports {version}; do not assume older details remained unchanged.",
                 "Use the following only when it agrees with supplied campaign evidence:",
                 "",
-                knowledge.content,
+                knowledge_content,
+            ]
+        )
+    elif knowledge.content and topics is not None:
+        lines.extend(
+            [
+                "",
+                f"Verified mechanics are available through {knowledge.loaded_through},",
+                "but no topic-specific mechanics section was needed for this request.",
+                "Rely on supplied campaign evidence and the evidence hierarchy above.",
             ]
         )
     else:

--- a/stellaris_companion/personality.py
+++ b/stellaris_companion/personality.py
@@ -188,6 +188,7 @@ def build_optimized_prompt(
     game_context: dict | None = None,
     *,
     custom_instructions: str | None = None,
+    include_game_knowledge: bool = True,
 ) -> str:
     """Generate the optimal production prompt based on empirical testing.
 
@@ -289,12 +290,19 @@ If safe_to_claim_over_cap is false, do not present derived_status or derived_ove
 
     # Append game context (version/DLC awareness) if provided
     if game_context:
-        prompt += _build_game_context_block(game_context)
+        prompt += _build_game_context_block(
+            game_context,
+            include_game_knowledge=include_game_knowledge,
+        )
 
     return prompt
 
 
-def _build_game_context_block(game_context: dict) -> str:
+def _build_game_context_block(
+    game_context: dict,
+    *,
+    include_game_knowledge: bool = True,
+) -> str:
     """Build the internal game context block for version/DLC awareness.
 
     This block is appended to the system prompt but should never be
@@ -313,13 +321,6 @@ def _build_game_context_block(game_context: dict) -> str:
     missing = game_context.get("missing_dlcs", [])
 
     dlcs_str = ", ".join(dlcs) if dlcs else "None (base game only)"
-
-    knowledge_prompt = build_game_knowledge_prompt(
-        version,
-        purpose="advisor",
-        patches_dir=PATCHES_DIR,
-        snapshots_dir=PATCH_SNAPSHOTS_DIR,
-    )
 
     # Build inline missing-DLC enumeration (hypothesis E approach)
     missing_lines = []
@@ -345,7 +346,14 @@ VERSION & DLC AWARENESS:
 - Never mention version numbers to the user.
 - Never mention DLC status unprompted."""
 
-    context += f"\n\n{knowledge_prompt}"
+    if include_game_knowledge:
+        knowledge_prompt = build_game_knowledge_prompt(
+            version,
+            purpose="advisor",
+            patches_dir=PATCHES_DIR,
+            snapshots_dir=PATCH_SNAPSHOTS_DIR,
+        )
+        context += f"\n\n{knowledge_prompt}"
 
     return context
 

--- a/tests/test_advisor_providers.py
+++ b/tests/test_advisor_providers.py
@@ -133,6 +133,48 @@ def test_compatible_generator_sends_common_chat_contract():
     }
 
 
+def test_compatible_generator_reuses_and_closes_its_connection_pool(monkeypatch):
+    clients = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+            self.call_count = 0
+            clients.append(self)
+
+        def post(self, url, **kwargs):
+            del url, kwargs
+            self.call_count += 1
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Ready."}}]},
+            )
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr("backend.core.advisor_providers.httpx.Client", FakeClient)
+    generator = OpenAICompatibleAdvisorGenerator(
+        config=AdvisorProviderConfig(
+            provider="ollama",
+            model="local-model",
+            base_url="http://127.0.0.1:11434/v1",
+        )
+    )
+
+    generator.generate(system_prompt="system", user_prompt="first")
+    generator.generate(system_prompt="system", user_prompt="second")
+
+    assert len(clients) == 1
+    assert clients[0].call_count == 2
+    assert clients[0].closed is False
+
+    generator.close()
+
+    assert clients[0].closed is True
+
+
 def test_compatible_generator_reports_auth_failure_without_exposing_key():
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/tests/test_campaign_history.py
+++ b/tests/test_campaign_history.py
@@ -206,13 +206,15 @@ def test_permanent_delete_is_isolated_to_one_campaign(tmp_path):
     db.close()
 
 
-def test_upgrade_from_v9_creates_backup_and_preserves_cache_bytes(tmp_path):
+def test_upgrade_from_v085_schema_creates_backup_and_preserves_cache_bytes(tmp_path):
     path = tmp_path / "history.db"
     db = GameDatabase(path)
     _add_campaign(db, save_id="alpha", empire_name="Alpha Union")
     before = _cache_rows(db)
     db.execute("DROP TABLE chronicle_revisions;")
     db.execute("DROP TABLE playthrough_metadata;")
+    # v0.8.5 shipped schema 9. Recreate that exact boundary before opening the
+    # database with the campaign-history release.
     db.execute("UPDATE schema_version SET version = 9;")
     db.execute("PRAGMA user_version = 9;")
     db.close()

--- a/tests/test_chronicle.py
+++ b/tests/test_chronicle.py
@@ -1604,6 +1604,7 @@ class TestChronicleProviderRouting:
             briefing={
                 "meta": {"version": "Pegasus v4.4.6"},
                 "identity": {"empire_name": "Test Empire", "ethics": []},
+                "military": {"naval_capacity": {"used": 20}},
             },
             previous_chapters=[],
             start_date="2200.01.01",

--- a/tests/test_companion_dlc_context.py
+++ b/tests/test_companion_dlc_context.py
@@ -143,15 +143,17 @@ def test_advisor_prompt_uses_exact_pegasus_patch_overlays(companion, version, in
         },
     )
 
-    for fact in included:
-        assert fact in companion.system_prompt
-    for fact in excluded:
-        assert fact not in companion.system_prompt
-    assert (
-        "Supplied save observations and recorded events are authoritative"
-        in companion.system_prompt
+    knowledge_prompt = companion._build_advisor_game_knowledge(
+        "operational reserves, resource abundance, and astral rift automation"
     )
-    assert "Mods can change baseline mechanics" in companion.system_prompt
+
+    assert "INTERNAL GAME KNOWLEDGE" not in companion.system_prompt
+    for fact in included:
+        assert fact in knowledge_prompt
+    for fact in excluded:
+        assert fact not in knowledge_prompt
+    assert "Supplied save observations and recorded events are authoritative" in knowledge_prompt
+    assert "Mods can change baseline mechanics" in knowledge_prompt
 
 
 def test_build_game_context_prefers_metadata_missing_dlcs_without_extractor(companion):

--- a/tests/test_game_knowledge.py
+++ b/tests/test_game_knowledge.py
@@ -95,3 +95,44 @@ def test_advisor_prompt_does_not_extend_rules_into_unverified_outcomes():
 
     assert "extend a listed rule into an unstated automatic outcome" in prompt
     assert "Verify arithmetic before using a calculated value" in prompt
+
+
+def test_topic_focused_prompt_keeps_only_relevant_mechanics_and_guardrails():
+    full_prompt = build_game_knowledge_prompt("Pegasus v4.4.6", purpose="advisor")
+    focused_prompt = build_game_knowledge_prompt(
+        "Pegasus v4.4.6",
+        purpose="advisor",
+        topics="Should I add anchorages before expanding my fleet and naval capacity?",
+    )
+
+    assert "A normal Anchorage adds 5 Naval Capacity" in focused_prompt
+    assert "Critical 4.x Baseline" in focused_prompt
+    assert "Interpretation Guardrails" in focused_prompt
+    assert "Psionics & the Shroud" not in focused_prompt
+    assert "Nomadic Empires & Arkships" not in focused_prompt
+    assert len(focused_prompt) < len(full_prompt) / 2
+
+
+def test_topic_focused_prompt_prefers_newer_overlay_sections():
+    prompt = build_game_knowledge_prompt(
+        "Pegasus v4.4.5",
+        purpose="advisor",
+        topics="operational reserves, resource abundance, and automation",
+    )
+
+    assert "Operational Reserves track Energy and Minerals one-to-one" in prompt
+    assert "Resource Abundance slider" in prompt
+    assert "uses a 3:1 rule rather than one-to-one conversion" not in prompt
+    assert "Automated Science Ships return normally after exploring Astral Rifts" not in prompt
+
+
+def test_topic_focused_prompt_does_not_misreport_available_older_coverage():
+    prompt = build_game_knowledge_prompt(
+        "Cetus v4.3.5",
+        purpose="advisor",
+        topics="What should I prioritize next?",
+    )
+
+    assert "Verified mechanics are available through 4.3.5" in prompt
+    assert "no topic-specific mechanics section was needed" in prompt
+    assert "No verified mechanics pack covers" not in prompt


### PR DESCRIPTION
## What changed

- Simplifies AI provider setup and Chronicle refresh controls.
- Focuses Campaign History on safe primary actions and lazy-loads the manager.
- Reduces repeated game-knowledge prompt overhead while retaining evidence guardrails.
- Reuses compatible-provider connections and centralizes backend IPC sender validation.
- Updates dependencies, clears current advisories, and makes the full validation suite a release prerequisite.
- Sets the app version to `1.0.0-beta.1` and adds the approved user-facing release notes.

## Why

This rolls the four 0.9 betas into a clearer, safer v1 beta for a broader audience. It keeps the existing unsigned Windows release path, preserves the MCP Relay name, and strengthens validation before any release assets are published.

## User impact

Users get simpler provider choices, safer campaign management, more accurate Advisor and Chronicle responses, faster AI requests, and more reliable updates. Existing Chronicles and campaign history remain protected through the database upgrade path.

## Validation

- Python: Ruff clean; 370 passed, 27 skipped.
- Rust: format and Clippy clean; 37 passed; release build completed.
- Electron: 48 unit tests passed.
- Desktop E2E: 14 passed.
- npm audits: zero vulnerabilities in both Electron trees.
- Bundled backend: MCP stdio and Electron boot smoke checks passed.
- MCP Relay package generated as `stellaris-companion-mcp-relay-1.0.0-beta.1.mcpb`.
- Unsigned macOS arm64 application bundle assembled locally.