### PR TITLE
Fix Intel Mac packaging for v1 beta

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,4 +5,4 @@ Stellaris Companion Backend
 Electron app backend with a configurable strategic advisor for Stellaris.
 """
 
-__version__ = "1.0.0-beta.1"
+__version__ = "1.0.0-beta.2"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellaris-companion",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellaris-companion",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "electron-store": "^8.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellaris-companion",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Desktop companion app for Stellaris - AI-powered strategic advisor",
   "main": "main.js",
   "author": "Stellaris Companion",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "google-genai>=1.0.0",
-    # Keep macOS PyInstaller bundles on pyca's statically-linked universal wheel.
-    "cryptography==50.0.0",
+    # Pin the tested API-key auth stack so release bundles remain reproducible.
+    "google-genai==1.57.0",
+    "google-auth==2.47.0",
     "python-dotenv>=1.0.0",
     "watchdog>=3.0",
     "fastapi>=0.100.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellaris-companion"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 description = "AI-powered strategic advisor for Stellaris with configurable model providers"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## What changed
- Pin the tested Gemini SDK and Google Auth versions used by the beta implementation.
- Remove the redundant direct `cryptography` pin that introduced incompatible Intel Mac OpenSSL linkage.
- Advance synchronized app metadata to `1.0.0-beta.2` while retaining the approved release notes.

## Why
The `v1.0.0-beta.1` release workflow passed validation and built Linux, Windows, and Apple Silicon successfully, but the Intel Mac backend failed its boot smoke test. CI had resolved the unbounded Gemini SDK to a new 2.x release, forcing `cryptography 50` to compile against Homebrew OpenSSL; PyInstaller then bundled a different `libssl.3.dylib` and the backend could not load `_SSL_get0_group_name`.

The app uses Gemini API-key authentication and is already tested against `google-genai 1.57.0` / `google-auth 2.47.0`. Pinning that pair removes the incompatible unused crypto module and makes release inputs reproducible.

## Validation
- Python lint and format checks pass.
- 370 Python tests pass; 27 external-fixture tests skip as expected.
- Fresh Python 3.11 resolution selects Gemini SDK 1.57.0 and Google Auth 2.47.0 with no `cryptography` artifact.
- Runtime dependency audit reports no known vulnerabilities.
- Bundled backend boot and MCP Relay stdio smoke checks pass.
- Version sync and beta channel classification pass.