### PR TITLE
Fix war battle attribution and prepare 1.0.0-beta.3

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,4 +5,4 @@ Stellaris Companion Backend
 Electron app backend with a configurable strategic advisor for Stellaris.
 """
 
-__version__ = "1.0.0-beta.2"
+__version__ = "1.0.0-beta.3"

--- a/backend/api/server.py
+++ b/backend/api/server.py
@@ -7,6 +7,7 @@ the Python backend. All endpoints require Bearer token authentication.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import os
@@ -33,6 +34,15 @@ _chronicle_in_flight_lock = threading.Lock()
 # Auth configuration
 ENV_API_TOKEN = "STELLARIS_API_TOKEN"
 security = HTTPBearer(auto_error=False)
+
+
+def _extract_war_diagnostics(save_path: Path) -> dict[str, Any]:
+    """Extract a bounded battle calculation trace for opt-in issue reports."""
+    from stellaris_companion.rust_bridge import session as rust_session
+    from stellaris_save_extractor import SaveExtractor
+
+    with rust_session(str(save_path)):
+        return SaveExtractor(str(save_path)).get_war_diagnostics(max_battles=120)
 
 
 class ChatRequest(BaseModel):
@@ -406,6 +416,7 @@ def create_app() -> FastAPI:
             "ingestionLastError": None,
             "precomputeReady": None,
             "t2Ready": None,
+            "warDiagnostics": None,
         }
 
         ingestion = getattr(request.app.state, "ingestion", None)
@@ -460,6 +471,24 @@ def create_app() -> FastAPI:
                     diagnostics["empireCivics"] = identity.get("civics", [])
                     diagnostics["empireOrigin"] = identity.get("origin")
                     diagnostics["empireType"] = identity.get("authority")
+
+        # Battle-side traces are opt-in through the report modal's diagnostics
+        # checkbox. Compute them on demand so the full save is never uploaded or
+        # retained in the issue payload.
+        current_save_path = None
+        if companion is not None:
+            current_save_path = getattr(companion, "save_path", None)
+        if current_save_path is None and ingestion is not None:
+            status = ingestion.get_status()
+            current_save_path = status.get("current_save_path")
+        if current_save_path:
+            path = Path(current_save_path)
+            if path.is_file():
+                with contextlib.suppress(Exception):
+                    diagnostics["warDiagnostics"] = await asyncio.to_thread(
+                        _extract_war_diagnostics,
+                        path,
+                    )
 
         return diagnostics
 

--- a/backend/core/advisor_memory.py
+++ b/backend/core/advisor_memory.py
@@ -1,0 +1,21 @@
+"""Helpers for keeping persisted Advisor memory limited to player intent."""
+
+from __future__ import annotations
+
+
+def sanitize_advisor_memory(summary: str | None) -> str:
+    """Strip legacy persisted Advisor answers while retaining player requests.
+
+    Older versions stored ``User asked: ... | Advisor suggested: ...``. The
+    suggestion often contained time-sensitive campaign claims, so replaying it
+    after a new save was ingested could contradict the current briefing.
+    """
+    lines: list[str] = []
+    for raw_line in str(summary or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if " | Advisor suggested:" in line:
+            line = line.split(" | Advisor suggested:", 1)[0].rstrip()
+        lines.append(line)
+    return "\n".join(lines)

--- a/backend/core/companion.py
+++ b/backend/core/companion.py
@@ -34,6 +34,7 @@ except ModuleNotFoundError as exc:
         ) from exc
     raise
 
+from backend.core.advisor_memory import sanitize_advisor_memory
 from backend.core.advisor_providers import (
     ADVISOR_PROVIDER_GEMINI,
     AdvisorGenerator,
@@ -713,7 +714,8 @@ class Companion:
             summary = db.get_advisor_memory_summary(save_id, language=language)
             if not summary:
                 return None
-            return summary[: self._max_save_memory_chars]
+            sanitized = sanitize_advisor_memory(summary)
+            return sanitized[: self._max_save_memory_chars] or None
         except Exception:
             return None
 
@@ -722,25 +724,23 @@ class Companion:
         *,
         save_id: str | None,
         question: str,
-        answer: str,
         game_date: str | None,
         language: str = "en",
     ) -> None:
-        """Append a compact memory entry and persist per-save summary."""
+        """Persist player intent without carrying forward Advisor factual claims."""
         if not save_id:
             return
 
         q = self._normalize_text_line(question, limit=180)
-        a = self._normalize_text_line(answer, limit=280)
         stamp = str(game_date or "date-unknown")
-        entry = f"- [{stamp}] User asked: {q} | Advisor suggested: {a}"
+        entry = f"- [{stamp}] Player topic/request: {q}"
 
         try:
             from backend.core.database import get_default_db
 
             db = get_default_db()
             existing = db.get_advisor_memory_summary(save_id, language=language) or ""
-            lines = [ln.strip() for ln in existing.splitlines() if ln.strip()]
+            lines = sanitize_advisor_memory(existing).splitlines()
 
             # Keep recent continuity, then append current turn.
             if len(lines) >= self._max_save_memory_entries:
@@ -1029,6 +1029,7 @@ class Companion:
             "- Treat model_context as the semantic contract for interpreting that JSON.\n"
             "- Do NOT call tools or ask to call tools.\n"
             "- ALL numbers and factual claims must come from the JSON.\n"
+            "- Current EMPIRE STATE overrides SAVE MEMORY and prior Advisor claims.\n"
             "- If a value is missing, say so in the requested language and suggest what to check in-game.\n"
             "- Be a strategic ADVISOR: interpret, prioritize, and recommend next actions.\n"
         )
@@ -1100,7 +1101,6 @@ class Companion:
             self._update_save_memory_summary(
                 save_id=save_id,
                 question=cleaned_question,
-                answer=response_text_raw,
                 game_date=game_date,
                 language=output_language,
             )

--- a/backend/core/conversation.py
+++ b/backend/core/conversation.py
@@ -217,6 +217,10 @@ class ConversationManager:
 
         if long_term_summary:
             lines.append("SAVE MEMORY (key goals and prior commitments):")
+            lines.append(
+                "Use this only as prior player intent or preference. It is not evidence about "
+                "the current campaign, and the current EMPIRE STATE overrides any conflict."
+            )
             lines.append(long_term_summary[: self.max_summary_chars])
             lines.append("")
 

--- a/backend/core/model_briefing.py
+++ b/backend/core/model_briefing.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from backend.core.json_utils import json_dumps
 
-MODEL_BRIEFING_SCHEMA_VERSION = 1
+MODEL_BRIEFING_SCHEMA_VERSION = 2
 
 
 def build_model_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
@@ -25,6 +25,8 @@ def build_model_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
     meta = result.get("meta") if isinstance(result.get("meta"), dict) else {}
     version = str(meta.get("version") or "").strip()
     major_version = _major_version(version)
+
+    _add_model_facing_war_stats(result)
 
     population: dict[str, Any] = {
         "unit": "in-game population",
@@ -63,6 +65,28 @@ def build_model_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
                 "hostility, awakening, or path-blocking evidence."
             )
         },
+        "military": {
+            "wars": {
+                "participation_scope": (
+                    "battle_stats cover only engagements where the player country directly "
+                    "participated; allied-only engagements are excluded."
+                ),
+                "side_scope": (
+                    "Victory and casualty fields are parent-war coalition totals. In a "
+                    "multi-country engagement, our_side losses may include allied casualties."
+                ),
+                "assessment_rule": (
+                    "Battle history is tactical evidence, not a complete measure of overall war "
+                    "progress. Consider occupation, war goals, controlled capitals and systems, "
+                    "and current military strength before declaring a war won or lost."
+                ),
+                "preferred_fields": (
+                    "Use the explicit player_involved_battles, our_side_victories, "
+                    "opposing_side_victories, our_side_ship_losses, and "
+                    "opposing_side_ship_losses aliases when discussing battle history."
+                ),
+            }
+        },
         "evidence": {
             "instruction": (
                 "Treat save-derived fields as observations. Clearly label strategic forecasts "
@@ -71,6 +95,39 @@ def build_model_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
         },
     }
     return result
+
+
+def _add_model_facing_war_stats(briefing: dict[str, Any]) -> None:
+    """Add unambiguous aliases without changing the stored extraction artifact."""
+    military = briefing.get("military")
+    if not isinstance(military, dict):
+        return
+    wars_block = military.get("wars")
+    if not isinstance(wars_block, dict):
+        return
+    wars = wars_block.get("wars")
+    if not isinstance(wars, list):
+        return
+
+    aliases = {
+        "player_involved_battles": "total_battles",
+        "our_side_victories": "our_victories",
+        "opposing_side_victories": "their_victories",
+        "unknown_outcomes": "unknown_outcomes",
+        "our_side_ship_losses": "our_ship_losses",
+        "opposing_side_ship_losses": "their_ship_losses",
+        "our_side_army_losses": "our_army_losses",
+        "opposing_side_army_losses": "their_army_losses",
+    }
+    for war in wars:
+        if not isinstance(war, dict):
+            continue
+        stats = war.get("battle_stats")
+        if not isinstance(stats, dict):
+            continue
+        for alias, source in aliases.items():
+            if source in stats:
+                stats[alias] = stats[source]
 
 
 def build_model_briefing_json(raw_briefing_json: str) -> str:

--- a/backend/mcp/context.py
+++ b/backend/mcp/context.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from backend.core.advisor_memory import sanitize_advisor_memory
 from backend.core.database import GameDatabase
 from backend.core.language import language_name, normalize_language
 
@@ -244,7 +245,12 @@ class StellarisMcpContext:
                 "events", []
             ),
             "advisor_custom_instructions": self._get_advisor_custom(session_id),
-            "advisor_memory": self.db.get_advisor_memory_summary(save_id, language=self.language)
+            "advisor_memory": (
+                sanitize_advisor_memory(
+                    self.db.get_advisor_memory_summary(save_id, language=self.language)
+                )
+                or None
+            )
             if save_id
             else None,
             "response_guidance": self._advisor_response_guidance(briefing),

--- a/docs/feedback-reporting.md
+++ b/docs/feedback-reporting.md
@@ -18,10 +18,13 @@ By default, submitting a report includes only basic environment info (app versio
 
 The following are opt-in toggles in the modal:
 
-- Game diagnostics (save metadata, DLC count, empire identity)
+- Game diagnostics (save metadata, DLC count, empire identity, and a bounded war-calculation trace)
 - Backend log tail (last ~32KB)
 - Screenshot (submitted reports upload a temporary image URL)
 - Error stack / LLM prompt-response context (when available)
+
+War diagnostics include country IDs, raw battle-side result/loss fields, and the
+calculated player-side result. They do not include or upload the save file.
 
 ## Maintainer triage + Jules workflow
 

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellaris-companion",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellaris-companion",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "electron-store": "^8.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellaris-companion",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Desktop companion app for Stellaris - AI-powered strategic advisor",
   "main": "main.js",
   "author": "Stellaris Companion",

--- a/electron/release-notes.md
+++ b/electron/release-notes.md
@@ -1,9 +1,6 @@
-**The largest Stellaris Companion update yet.**
+**More trustworthy war assessments.**
 
-- Added support for Gemini, Ollama, LM Studio, OpenRouter, and other compatible AI providers.
-- Added Campaign History with search, rename, trash, restore, cleanup, and protected Chronicle resets.
-- Improved Advisor and Chronicle accuracy with save-grounded evidence and verified Stellaris mechanics.
-- Simplified provider setup and Chronicle refresh controls.
-- Improved performance, dependency security, and release reliability.
-
-This is a major beta release. If something feels unclear or unreliable, please report it so we can polish the stable 1.0 release.
+- Corrected war victories, defeats, and casualties when tactical battle sides appear reversed in Stellaris saves.
+- Added occupation and capital-control evidence so the Advisor considers strategic progress as well as battle history.
+- Prevented stale Advisor responses from overriding evidence from the current save.
+- Added privacy-safe war diagnostics for future reports without uploading save files.

--- a/electron/renderer/components/ReportIssueModal.tsx
+++ b/electron/renderer/components/ReportIssueModal.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { HUDButton } from './hud/HUDButton'
 import { HUDSelect, HUDCheckbox } from './hud/HUDForm'
 import { HUDTextArea } from './hud/HUDInput'
+import type { WarDiagnostics } from '../hooks/useBackend'
 
 interface ReportContext {
   appVersion: string
@@ -24,6 +25,7 @@ interface ReportContext {
   ingestionLastError?: string
   precomputeReady?: boolean
   t2Ready?: boolean
+  warDiagnostics?: WarDiagnostics
   error?: {
     message: string
     stack?: string
@@ -114,6 +116,7 @@ export default function ReportIssueModal({ isOpen, onClose, prefill }: ReportIss
           ctx.ingestionLastError = diagnostics.ingestionLastError || undefined
           ctx.precomputeReady = typeof diagnostics.precomputeReady === 'boolean' ? diagnostics.precomputeReady : undefined
           ctx.t2Ready = typeof diagnostics.t2Ready === 'boolean' ? diagnostics.t2Ready : undefined
+          ctx.warDiagnostics = diagnostics.warDiagnostics || undefined
         } else {
           throw new Error('Diagnostics unavailable')
         }
@@ -168,6 +171,19 @@ export default function ReportIssueModal({ isOpen, onClose, prefill }: ReportIss
       if (ctx.empireCivics?.length) lines.push(`- Civics: ${ctx.empireCivics.join(', ')}`)
       if (ctx.dlcs?.length) lines.push(`- DLCs: ${ctx.dlcs.length} enabled`)
       if (ctx.ingestionLastError) lines.push(`- Ingestion last error: ${ctx.ingestionLastError}`)
+      if (ctx.warDiagnostics) {
+        const warDiagnosticsJson = JSON.stringify(ctx.warDiagnostics, null, 2)
+        lines.push('')
+        lines.push('<details><summary>War calculation diagnostics</summary>')
+        lines.push('')
+        lines.push('```json')
+        lines.push(warDiagnosticsJson.length > 24_000
+          ? `${warDiagnosticsJson.slice(0, 24_000).trimEnd()}...`
+          : warDiagnosticsJson)
+        lines.push('```')
+        lines.push('')
+        lines.push('</details>')
+      }
       lines.push('')
     }
 
@@ -308,7 +324,7 @@ export default function ReportIssueModal({ isOpen, onClose, prefill }: ReportIss
       }
 
       const payload = {
-        schema_version: 1,
+        schema_version: 2,
         submitted_at_ms: Date.now(),
         install_id: typeof installId === 'string' ? installId : undefined,
         category,
@@ -335,6 +351,7 @@ export default function ReportIssueModal({ isOpen, onClose, prefill }: ReportIss
               ingestionLastError: enriched.ingestionLastError,
               precomputeReady: enriched.precomputeReady,
               t2Ready: enriched.t2Ready,
+              warDiagnostics: enriched.warDiagnostics,
             }
             : undefined,
           error: includeErrorContext ? enriched.error : undefined,
@@ -472,7 +489,7 @@ export default function ReportIssueModal({ isOpen, onClose, prefill }: ReportIss
                 Optional (opt-in)
               </span>
               <HUDCheckbox
-                label="Include game diagnostics (DLCs, empire, save metadata)"
+                label="Include game diagnostics (metadata and bounded war calculations)"
                 checked={includeDiagnostics}
                 onChange={(e) => setIncludeDiagnostics(e.target.checked)}
               />

--- a/electron/renderer/hooks/useBackend.ts
+++ b/electron/renderer/hooks/useBackend.ts
@@ -289,6 +289,40 @@ export interface DiagnosticsResponse {
   ingestionLastError: string | null
   precomputeReady: boolean | null
   t2Ready: boolean | null
+  warDiagnostics: WarDiagnostics | null
+}
+
+export interface WarBattleDiagnosticRecord {
+  local_attacker_country_ids: string[]
+  local_defender_country_ids: string[]
+  raw_attacker_victory: unknown
+  raw_attacker_losses: number
+  raw_defender_losses: number
+  battle_type: string
+  system_id: string | null
+  computed_result: 'our_side_victory' | 'opposing_side_victory' | 'unknown'
+  computed_our_side_losses: number
+  computed_opposing_side_losses: number
+}
+
+export interface WarDiagnostic {
+  war_id: string
+  our_side: 'attacker' | 'defender'
+  attacker_country_ids: string[]
+  defender_country_ids: string[]
+  direct_battle_count: number
+  battle_records: WarBattleDiagnosticRecord[]
+  truncated: boolean
+}
+
+export interface WarDiagnostics {
+  schema_version: number
+  player_id: string
+  result_orientation: 'parent_war_side'
+  loss_orientation: 'parent_war_side'
+  wars: WarDiagnostic[]
+  included_battles: number
+  truncated: boolean
 }
 
 // ============================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellaris-companion"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 description = "AI-powered strategic advisor for Stellaris with configurable model providers"
 readme = "README.md"
 license = "MIT"

--- a/stellaris_save_extractor/military.py
+++ b/stellaris_save_extractor/military.py
@@ -11,6 +11,8 @@ from .fleet_classification import classify_owned_fleet
 
 logger = logging.getLogger(__name__)
 
+WAR_DIAGNOSTICS_SCHEMA_VERSION = 2
+
 
 class MilitaryMixin:
     """Domain methods extracted from the original SaveExtractor."""
@@ -48,6 +50,78 @@ class MilitaryMixin:
         Requires Rust session mode to be active.
         """
         return self._get_wars_rust()
+
+    def get_war_diagnostics(self, *, max_battles: int = 120) -> dict:
+        """Return a bounded, privacy-safe record of battle-side calculations.
+
+        This diagnostic deliberately excludes ship designs, coordinates, raw
+        country data, and the save itself. It is intended for opt-in feedback
+        reports where aggregate output is insufficient to reproduce a side
+        attribution problem.
+        """
+        session = _get_active_session()
+        if not session:
+            raise ParserError("Rust session mode required for get_war_diagnostics")
+
+        max_battles = max(1, min(int(max_battles), 250))
+        player_id = str(self.get_player_empire_id())
+        result = {
+            "schema_version": WAR_DIAGNOSTICS_SCHEMA_VERSION,
+            "player_id": player_id,
+            "result_orientation": "parent_war_side",
+            "loss_orientation": "parent_war_side",
+            "wars": [],
+            "included_battles": 0,
+            "truncated": False,
+        }
+
+        for war_id, war in session.iter_section("war"):
+            if not isinstance(war, dict):
+                continue
+            attacker_ids = self._war_participant_ids(war.get("attackers", []))
+            defender_ids = self._war_participant_ids(war.get("defenders", []))
+            player_is_war_attacker = player_id in attacker_ids
+            if not player_is_war_attacker and player_id not in defender_ids:
+                continue
+
+            war_diagnostic = {
+                "war_id": str(war_id),
+                "our_side": "attacker" if player_is_war_attacker else "defender",
+                "attacker_country_ids": sorted(attacker_ids),
+                "defender_country_ids": sorted(defender_ids),
+                "direct_battle_count": 0,
+                "battle_records": [],
+                "truncated": False,
+            }
+            battles = war.get("battles", [])
+            if not isinstance(battles, list):
+                battles = []
+            for battle in battles:
+                if not isinstance(battle, dict):
+                    continue
+                local_attackers = self._battle_participant_ids(battle.get("attackers", []))
+                local_defenders = self._battle_participant_ids(battle.get("defenders", []))
+                if player_id not in local_attackers and player_id not in local_defenders:
+                    continue
+
+                war_diagnostic["direct_battle_count"] += 1
+                if result["included_battles"] >= max_battles:
+                    war_diagnostic["truncated"] = True
+                    result["truncated"] = True
+                    continue
+
+                war_diagnostic["battle_records"].append(
+                    self._build_battle_diagnostic_record(
+                        battle,
+                        local_attackers=local_attackers,
+                        local_defenders=local_defenders,
+                        player_is_war_attacker=player_is_war_attacker,
+                    )
+                )
+                result["included_battles"] += 1
+            result["wars"].append(war_diagnostic)
+
+        return result
 
     def _resolve_war_name(self, name_block: dict | str | None, war_id: str) -> str:
         """Resolve a war name from its name block structure.
@@ -97,6 +171,13 @@ class MilitaryMixin:
         # it would trigger iter_section("galactic_object") *inside* the war
         # stream, corrupting the session (nested iter_section is not supported).
         self._get_galactic_objects_cached()
+
+        # Build occupation evidence before streaming the war section. Rust
+        # section streams cannot be nested, and these indexes use country,
+        # fleet, colony, and planet data referenced by every active war.
+        countries = self._get_countries_cached()
+        lost_control_records = self._build_lost_control_records(session, countries)
+        capital_control = self._build_capital_control_index(session, countries)
 
         # Iterate through wars using Rust parser (P031: use session.iter_section directly)
         for war_id, war_data in session.iter_section("war"):
@@ -148,6 +229,8 @@ class MilitaryMixin:
 
             # Build war info
             our_side = "attacker" if player_is_attacker else "defender"
+            our_side_ids = set(attacker_ids if player_is_attacker else defender_ids)
+            opposing_side_ids = set(defender_ids if player_is_attacker else attacker_ids)
 
             # Resolve country names
             attacker_names = [country_names.get(int(cid), f"Empire {cid}") for cid in attacker_ids]
@@ -162,6 +245,7 @@ class MilitaryMixin:
             battle_stats = self._extract_battle_stats(
                 war_data.get("battles", []),
                 player_id=player_id,
+                player_is_war_attacker=player_is_attacker,
             )
 
             war_info = {
@@ -175,6 +259,14 @@ class MilitaryMixin:
                 },
                 "war_goal": war_goal,
                 "battle_stats": battle_stats,
+                "strategic_control": self._summarize_war_control(
+                    lost_control_records=lost_control_records,
+                    capital_control=capital_control,
+                    our_side_ids=our_side_ids,
+                    opposing_side_ids=opposing_side_ids,
+                    player_id=player_id_str,
+                    country_names=country_names,
+                ),
                 "status": "in_progress",  # All wars in the war section are active
             }
 
@@ -191,28 +283,40 @@ class MilitaryMixin:
         battles: list,
         *,
         player_id: int | str,
+        player_is_war_attacker: bool,
     ) -> dict:
         """Extract battle statistics from the battles block.
 
         Args:
             battles: List of battle records from war data
             player_id: Country ID of the player empire
+            player_is_war_attacker: Whether the player belongs to the parent
+                war's attacker coalition. Stellaris stores battle outcomes and
+                loss totals relative to the parent war sides, even when the
+                per-battle participant lists use the opposite tactical order.
 
         Returns:
             Dict with battle statistics for battles where the player empire
             directly participated:
             - total_battles: Total number of player battles
-            - our_victories: Battles won by the player empire
-            - their_victories: Battles lost by the player empire
-            - our_ship_losses: Ships lost by the player empire
-            - their_ship_losses: Ships lost by the opponent
-            - our_army_losses: Armies lost by the player empire
-            - their_army_losses: Armies lost by the opponent
+            - our_victories: Battles won by the player's war side
+            - their_victories: Battles won by the opposing war side
+            - unknown_outcomes: Battles without a recognized result flag
+            - our_ship_losses: Ships lost by the player's war side
+            - their_ship_losses: Ships lost by the opposing war side
+            - our_army_losses: Armies lost by the player's war side
+            - their_army_losses: Armies lost by the opposing war side
+
+            The participant lists are used only to restrict the result to
+            engagements in which the player country directly participated.
+            Loss totals remain coalition-side values for those engagements and
+            may include allied casualties in multi-country battles.
         """
         stats = {
             "total_battles": 0,
             "our_victories": 0,
             "their_victories": 0,
+            "unknown_outcomes": 0,
             "our_ship_losses": 0,
             "their_ship_losses": 0,
             "our_army_losses": 0,
@@ -228,30 +332,21 @@ class MilitaryMixin:
             if not isinstance(battle, dict):
                 continue
 
-            # Determine battle outcome
-            # attacker_victory=yes means the battle's attackers won (not war attackers)
-            # We need to check whether the player's empire was attacking or defending
-            # in THIS battle. Coalition-wide battles should not be attributed to the
-            # player when only allies participated.
+            # The per-battle participant lists identify who directly fought, but
+            # attacker_victory and attacker/defender losses are relative to the
+            # parent war coalitions. The tactical list order can be the opposite
+            # of the parent war side in real saves.
             battle_attackers = self._battle_participant_ids(battle.get("attackers", []))
             battle_defenders = self._battle_participant_ids(battle.get("defenders", []))
-            attacker_victory = battle.get("attacker_victory") == "yes"
-
-            player_was_battle_attacker = player_id_str in battle_attackers
-            player_was_battle_defender = player_id_str in battle_defenders
-
-            if not player_was_battle_attacker and not player_was_battle_defender:
+            if player_id_str not in battle_attackers and player_id_str not in battle_defenders:
                 continue
 
             stats["total_battles"] += 1
 
-            # Determine if we won this battle
-            if (
-                player_was_battle_attacker
-                and attacker_victory
-                or player_was_battle_defender
-                and not attacker_victory
-            ):
+            war_attacker_won = self._parse_battle_outcome(battle.get("attacker_victory"))
+            if war_attacker_won is None:
+                stats["unknown_outcomes"] += 1
+            elif war_attacker_won == player_is_war_attacker:
                 stats["our_victories"] += 1
             else:
                 stats["their_victories"] += 1
@@ -266,8 +361,8 @@ class MilitaryMixin:
 
             battle_type = battle.get("type", "ships")
 
-            # Assign losses to our side vs their side
-            if player_was_battle_attacker:
+            # Loss fields use the same parent-war orientation as the result flag.
+            if player_is_war_attacker:
                 our_losses = attacker_losses
                 their_losses = defender_losses
             else:
@@ -323,6 +418,325 @@ class MilitaryMixin:
         ]
 
         return stats
+
+    def _build_lost_control_records(self, session, countries: dict[str, dict]) -> list[dict]:
+        """Return save-recorded starbases whose owner has lost control."""
+        pending: list[dict[str, str]] = []
+        for owner_id, country in countries.items():
+            if not isinstance(country, dict):
+                continue
+            fleet_manager = country.get("fleets_manager")
+            if not isinstance(fleet_manager, dict):
+                continue
+            owned_fleets = fleet_manager.get("owned_fleets", [])
+            if not isinstance(owned_fleets, list):
+                continue
+            for entry in owned_fleets:
+                if not isinstance(entry, dict) or entry.get("ownership_status") != "lost_control":
+                    continue
+                fleet_id = entry.get("fleet")
+                controller_id = entry.get("debtor")
+                if fleet_id is None or controller_id is None:
+                    continue
+                pending.append(
+                    {
+                        "owner_id": str(owner_id),
+                        "controller_id": str(controller_id),
+                        "fleet_id": str(fleet_id),
+                    }
+                )
+
+        if not pending:
+            return []
+
+        fleet_ids = list(dict.fromkeys(record["fleet_id"] for record in pending))
+        fleets: dict[str, dict] = {}
+        for entry in session.get_entries("fleet", fleet_ids):
+            fleet_id = entry.get("_key")
+            fleet = entry.get("_value")
+            if fleet_id is not None and isinstance(fleet, dict):
+                fleets[str(fleet_id)] = fleet
+
+        records: list[dict] = []
+        for record in pending:
+            fleet = fleets.get(record["fleet_id"])
+            if not isinstance(fleet, dict):
+                continue
+            if fleet.get("station") != "yes" and fleet.get("orbital_station") != "yes":
+                continue
+
+            system_id = self._fleet_system_id(fleet)
+            enriched: dict = dict(record)
+            enriched["system_id"] = system_id
+            if system_id is not None:
+                with contextlib.suppress(ValueError, TypeError):
+                    system_name = self._resolve_system_name(int(system_id))
+                    if system_name:
+                        enriched["system_name"] = system_name
+            records.append(enriched)
+        return records
+
+    @staticmethod
+    def _fleet_system_id(fleet: dict) -> str | None:
+        """Read a stationary fleet's current system from common save shapes."""
+        for block_name in ("movement_manager", "combat"):
+            block = fleet.get(block_name)
+            if not isinstance(block, dict):
+                continue
+            coordinate = block.get("coordinate")
+            if not isinstance(coordinate, dict):
+                continue
+            origin = coordinate.get("origin")
+            if origin is not None and str(origin) != "4294967295":
+                return str(origin)
+        return None
+
+    def _build_capital_control_index(
+        self,
+        session,
+        countries: dict[str, dict],
+    ) -> dict[str, dict]:
+        """Resolve capital colony controllers and systems across save schemas."""
+        try:
+            data = session.extract_sections(["colony", "colonies", "planets"])
+        except Exception as exc:
+            logger.debug("war_capital_control_unavailable error=%s", exc)
+            return {}
+
+        colonies = data.get("colony") or data.get("colonies", {})
+        if isinstance(colonies, dict):
+            nested_colonies = colonies.get("colony") or colonies.get("colonies")
+            if isinstance(nested_colonies, dict):
+                colonies = nested_colonies
+        else:
+            colonies = {}
+
+        planets = data.get("planets", {})
+        if isinstance(planets, dict) and isinstance(planets.get("planet"), dict):
+            planets = planets["planet"]
+        if not isinstance(planets, dict):
+            planets = {}
+
+        result: dict[str, dict] = {}
+        for country_id, country in countries.items():
+            if not isinstance(country, dict):
+                continue
+            capital_id = country.get("capital")
+            if capital_id is None:
+                continue
+            capital_id_str = str(capital_id)
+            colony = colonies.get(capital_id_str)
+            carrier: dict = {}
+            if isinstance(colony, dict):
+                carrier_id = self._capital_carrier_id(colony.get("carrier"))
+                if carrier_id is not None and isinstance(planets.get(carrier_id), dict):
+                    carrier = planets[carrier_id]
+            else:
+                colony = {}
+                if isinstance(planets.get(capital_id_str), dict):
+                    carrier = planets[capital_id_str]
+
+            controller_id = colony.get("controller") or carrier.get("controller")
+            coordinate = colony.get("coordinate") or carrier.get("coordinate")
+            system_id = (
+                str(coordinate.get("origin"))
+                if isinstance(coordinate, dict) and coordinate.get("origin") is not None
+                else None
+            )
+            name_block = colony.get("name") or carrier.get("name")
+            capital_name = None
+            if name_block:
+                capital_name = self.resolve_name(
+                    name_block,
+                    default="Unknown Capital",
+                    context="planet",
+                ).display
+
+            result[str(country_id)] = {
+                "capital_id": capital_id_str,
+                "controller_id": str(controller_id) if controller_id is not None else None,
+                "system_id": system_id,
+                "capital_name": capital_name,
+            }
+        return result
+
+    @staticmethod
+    def _capital_carrier_id(carrier: object) -> str | None:
+        """Normalize Pegasus colony carrier references to a planet ID."""
+        if isinstance(carrier, (str, int)) and not isinstance(carrier, bool):
+            return str(carrier)
+        if not isinstance(carrier, dict):
+            return None
+        for key in ("planet", "reference", "id", "carrier_id", "value"):
+            value = carrier.get(key)
+            if value is not None and not isinstance(value, (dict, list, bool)):
+                return str(value)
+        return None
+
+    @staticmethod
+    def _summarize_war_control(
+        *,
+        lost_control_records: list[dict],
+        capital_control: dict[str, dict],
+        our_side_ids: set[str],
+        opposing_side_ids: set[str],
+        player_id: str,
+        country_names: dict[int, str],
+    ) -> dict:
+        """Summarize occupation evidence relative to the player's war side."""
+        enemy_assets = [
+            record
+            for record in lost_control_records
+            if record.get("owner_id") in opposing_side_ids
+            and record.get("controller_id") in our_side_ids
+        ]
+        our_assets = [
+            record
+            for record in lost_control_records
+            if record.get("owner_id") in our_side_ids
+            and record.get("controller_id") in opposing_side_ids
+        ]
+
+        def systems(records: list[dict]) -> list[dict]:
+            by_id: dict[str, dict] = {}
+            for record in records:
+                system_id = record.get("system_id")
+                if system_id is None:
+                    continue
+                by_id.setdefault(
+                    str(system_id),
+                    {
+                        "system_id": str(system_id),
+                        "system_name": record.get("system_name"),
+                    },
+                )
+            return list(by_id.values())
+
+        enemy_systems = systems(enemy_assets)
+        our_systems = systems(our_assets)
+        enemy_system_ids = {entry["system_id"] for entry in enemy_systems}
+        our_system_ids = {entry["system_id"] for entry in our_systems}
+
+        def empire_name(country_id: str) -> str:
+            with contextlib.suppress(ValueError, TypeError):
+                return country_names.get(int(country_id), f"Empire {country_id}")
+            return f"Empire {country_id}"
+
+        occupied_enemy_capitals: list[dict] = []
+        controlled_enemy_capital_systems: list[dict] = []
+        for country_id in sorted(opposing_side_ids):
+            capital = capital_control.get(country_id, {})
+            capital_info = {
+                "empire": empire_name(country_id),
+                "empire_id": country_id,
+                "capital": capital.get("capital_name"),
+                "system_id": capital.get("system_id"),
+            }
+            if capital.get("controller_id") in our_side_ids:
+                occupied_enemy_capitals.append(capital_info)
+            if capital.get("system_id") in enemy_system_ids:
+                controlled_enemy_capital_systems.append(capital_info)
+
+        player_capital = capital_control.get(player_id, {})
+        player_capital_system_id = player_capital.get("system_id")
+        player_capital_controller = player_capital.get("controller_id")
+        player_capital_system_lost = (
+            player_capital_system_id in our_system_ids
+            if player_capital_system_id is not None
+            else None
+        )
+        player_capital_occupied = (
+            player_capital_controller in opposing_side_ids
+            if player_capital_controller is not None
+            else None
+        )
+
+        return {
+            "enemy_starbase_assets_controlled_by_our_side": len(enemy_assets),
+            "enemy_systems_controlled_by_our_side": enemy_systems,
+            "enemy_assets_controlled_by_player": sum(
+                record.get("controller_id") == player_id for record in enemy_assets
+            ),
+            "our_starbase_assets_controlled_by_enemy_side": len(our_assets),
+            "our_systems_controlled_by_enemy_side": our_systems,
+            "enemy_capital_colonies_occupied_by_our_side": occupied_enemy_capitals,
+            "enemy_capital_systems_controlled_by_our_side": controlled_enemy_capital_systems,
+            "player_capital_colony_occupied_by_enemy_side": player_capital_occupied,
+            "player_capital_system_controlled_by_enemy_side": player_capital_system_lost,
+            "evidence_scope": (
+                "Save-recorded lost-control starbase assets and capital colony controllers; "
+                "this is strategic control evidence, not a complete war-score calculation."
+            ),
+        }
+
+    @staticmethod
+    def _parse_battle_outcome(value: object) -> bool | None:
+        """Return whether the parent war attacker won, or None if unknown."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"yes", "true", "1"}:
+                return True
+            if normalized in {"no", "false", "0"}:
+                return False
+        if isinstance(value, int) and value in {0, 1}:
+            return bool(value)
+        return None
+
+    @staticmethod
+    def _war_participant_ids(participants: object) -> set[str]:
+        """Normalize parent-war participant records into country IDs."""
+        if not isinstance(participants, list):
+            participants = [participants] if participants else []
+        result: set[str] = set()
+        for participant in participants:
+            if isinstance(participant, dict):
+                country_id = participant.get("country")
+                if country_id is not None:
+                    result.add(str(country_id))
+        return result
+
+    def _build_battle_diagnostic_record(
+        self,
+        battle: dict,
+        *,
+        local_attackers: set[str],
+        local_defenders: set[str],
+        player_is_war_attacker: bool,
+    ) -> dict:
+        """Build one bounded battle calculation record for feedback reports."""
+        attacker_losses = 0
+        defender_losses = 0
+        with contextlib.suppress(ValueError, TypeError):
+            attacker_losses = int(battle.get("attacker_losses", 0))
+        with contextlib.suppress(ValueError, TypeError):
+            defender_losses = int(battle.get("defender_losses", 0))
+
+        war_attacker_won = self._parse_battle_outcome(battle.get("attacker_victory"))
+        if war_attacker_won is None:
+            computed_result = "unknown"
+        elif war_attacker_won == player_is_war_attacker:
+            computed_result = "our_side_victory"
+        else:
+            computed_result = "opposing_side_victory"
+
+        return {
+            "local_attacker_country_ids": sorted(local_attackers),
+            "local_defender_country_ids": sorted(local_defenders),
+            "raw_attacker_victory": battle.get("attacker_victory"),
+            "raw_attacker_losses": attacker_losses,
+            "raw_defender_losses": defender_losses,
+            "battle_type": battle.get("type", "ships"),
+            "system_id": str(battle.get("system")) if battle.get("system") is not None else None,
+            "computed_result": computed_result,
+            "computed_our_side_losses": (
+                attacker_losses if player_is_war_attacker else defender_losses
+            ),
+            "computed_opposing_side_losses": (
+                defender_losses if player_is_war_attacker else attacker_losses
+            ),
+        }
 
     @staticmethod
     def _battle_participant_ids(participants: object) -> set[str]:

--- a/stellaris_save_extractor/validation.py
+++ b/stellaris_save_extractor/validation.py
@@ -311,6 +311,7 @@ class ExtractionValidator:
                 "total_battles",
                 "our_victories",
                 "their_victories",
+                "unknown_outcomes",
                 "our_ship_losses",
                 "their_ship_losses",
                 "our_army_losses",
@@ -327,21 +328,27 @@ class ExtractionValidator:
                 else:
                     result.add_pass()
 
-            # Victories should not exceed total battles
+            # Every directly-involved battle must have exactly one classified
+            # outcome, including an explicit unknown bucket for malformed or
+            # future save-schema values.
             total = battle_stats.get("total_battles", 0)
             our_wins = battle_stats.get("our_victories", 0)
             their_wins = battle_stats.get("their_victories", 0)
-            if our_wins + their_wins > total:
+            unknown = battle_stats.get("unknown_outcomes", 0)
+            classified = our_wins + their_wins + unknown
+            if classified != total:
                 result.add_issue(
                     "battle_stats_invariant",
-                    f"Victories ({our_wins}+{their_wins}) exceed total battles ({total}) in '{war_name}'",
+                    f"Classified outcomes ({our_wins}+{their_wins}+{unknown}) do not equal "
+                    f"total battles ({total}) in '{war_name}'",
                     details={
                         "war": war_name,
                         "total": total,
                         "our_wins": our_wins,
                         "their_wins": their_wins,
+                        "unknown": unknown,
                     },
-                    fix_suggestion="Check battle victory counting logic",
+                    fix_suggestion="Check battle outcome classification logic",
                 )
             else:
                 result.add_pass()

--- a/tests/fixtures/player_war_attacker_battles.json
+++ b/tests/fixtures/player_war_attacker_battles.json
@@ -1,0 +1,52 @@
+{
+  "player_id": "0",
+  "player_is_war_attacker": true,
+  "battles": [
+    {
+      "attackers": ["15"],
+      "defenders": ["0"],
+      "attacker_victory": "yes",
+      "attacker_losses": "1",
+      "defender_losses": "15",
+      "system": "2",
+      "type": "ships"
+    },
+    {
+      "attackers": ["0"],
+      "defenders": ["15"],
+      "attacker_victory": "no",
+      "attacker_losses": "4",
+      "defender_losses": "2",
+      "system": "3",
+      "type": "armies"
+    },
+    {
+      "attackers": ["1"],
+      "defenders": ["15"],
+      "attacker_victory": "yes",
+      "attacker_losses": "25",
+      "defender_losses": "0",
+      "system": "1",
+      "type": "ships"
+    },
+    {
+      "attackers": ["15"],
+      "defenders": ["0", "1"],
+      "attacker_victory": "future_value",
+      "attacker_losses": "2",
+      "defender_losses": "3",
+      "system": "4",
+      "type": "ships"
+    }
+  ],
+  "expected": {
+    "total_battles": 3,
+    "our_victories": 1,
+    "their_victories": 1,
+    "unknown_outcomes": 1,
+    "our_ship_losses": 3,
+    "their_ship_losses": 18,
+    "our_army_losses": 4,
+    "their_army_losses": 2
+  }
+}

--- a/tests/test_chat_memory.py
+++ b/tests/test_chat_memory.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from backend.core.advisor_memory import sanitize_advisor_memory
 from backend.core.conversation import ConversationManager
 from backend.core.database import GameDatabase
 
@@ -137,3 +138,33 @@ def test_save_scoped_advisor_memory_persists_round_trip(tmp_path: Path) -> None:
         assert "early alloy rush" not in second
     finally:
         db.close()
+
+
+def test_save_memory_prompt_cannot_override_current_empire_state() -> None:
+    manager = ConversationManager()
+
+    prompt = manager.build_prompt(
+        session_key="scope-memory",
+        briefing_json='{"military":{"wars":{"wars":[]}}}',
+        game_date="2303.01.01",
+        question="How is the war going?",
+        long_term_summary="- Advisor previously claimed every battle was lost.",
+    )
+
+    assert "current EMPIRE STATE overrides any conflict" in prompt
+    assert "not evidence about the current campaign" in prompt
+
+
+def test_legacy_save_memory_drops_advisor_factual_claims() -> None:
+    summary = (
+        "- [2302.01.01] User asked: How is the war? | "
+        "Advisor suggested: All 47 battles were defeats.\n"
+        "- [2302.07.01] Player topic/request: Protect the eastern border"
+    )
+
+    sanitized = sanitize_advisor_memory(summary)
+
+    assert "How is the war?" in sanitized
+    assert "Protect the eastern border" in sanitized
+    assert "47 battles" not in sanitized
+    assert "Advisor suggested" not in sanitized

--- a/tests/test_military.py
+++ b/tests/test_military.py
@@ -1,7 +1,9 @@
 """Focused tests for military extraction helpers."""
 
+import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -19,57 +21,82 @@ class DummyMilitaryExtractor(MilitaryMixin):
             1: "Ignored System",
             2: "Player Victory System",
             3: "Player Defense System",
+            4: "Unknown Outcome System",
         }
 
     def _resolve_system_name(self, system_id: int) -> str:
         return self._systems.get(system_id, f"System {system_id}")
 
 
-def test_extract_battle_stats_counts_only_player_battles():
+def test_extract_battle_stats_uses_parent_war_side_fixture():
     extractor = DummyMilitaryExtractor()
-    battles = [
-        {
-            "attackers": ["16777220"],
-            "defenders": ["15"],
-            "attacker_victory": "no",
-            "attacker_losses": "25",
-            "defender_losses": "0",
-            "system": "1",
-            "type": "ships",
-        },
-        {
-            "attackers": ["0"],
-            "defenders": ["15"],
-            "attacker_victory": "yes",
-            "attacker_losses": "1",
-            "defender_losses": "10",
-            "system": "2",
-            "type": "ships",
-        },
-        {
-            "attackers": ["15"],
-            "defenders": ["0"],
-            "attacker_victory": "yes",
-            "attacker_losses": "3",
-            "defender_losses": "7",
-            "system": "3",
-            "type": "armies",
-        },
-    ]
+    fixture_path = Path(__file__).parent / "fixtures" / "player_war_attacker_battles.json"
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
 
-    stats = extractor._extract_battle_stats(battles, player_id=0)
+    stats = extractor._extract_battle_stats(
+        fixture["battles"],
+        player_id=fixture["player_id"],
+        player_is_war_attacker=fixture["player_is_war_attacker"],
+    )
 
-    assert stats["total_battles"] == 2
-    assert stats["our_victories"] == 1
-    assert stats["their_victories"] == 1
-    assert stats["our_ship_losses"] == 1
-    assert stats["their_ship_losses"] == 10
-    assert stats["our_army_losses"] == 7
-    assert stats["their_army_losses"] == 3
+    for key, expected in fixture["expected"].items():
+        assert stats[key] == expected
     assert {loc["system"] for loc in stats["battle_locations"]} == {
-        "Player Victory System",
+        "Unknown Outcome System",
         "Player Defense System",
+        "Player Victory System",
     }
+
+
+@pytest.mark.parametrize(
+    (
+        "player_is_war_attacker",
+        "local_player_side",
+        "attacker_victory",
+        "expected_our_victories",
+        "expected_their_victories",
+        "expected_our_losses",
+        "expected_their_losses",
+    ),
+    [
+        (True, "defenders", "yes", 1, 0, 2, 9),
+        (True, "attackers", "no", 0, 1, 2, 9),
+        (False, "attackers", "yes", 0, 1, 9, 2),
+        (False, "defenders", "no", 1, 0, 9, 2),
+    ],
+)
+def test_extract_battle_stats_outcome_matrix_uses_parent_war_side(
+    player_is_war_attacker,
+    local_player_side,
+    attacker_victory,
+    expected_our_victories,
+    expected_their_victories,
+    expected_our_losses,
+    expected_their_losses,
+):
+    extractor = DummyMilitaryExtractor()
+    battle = {
+        "attackers": ["0"] if local_player_side == "attackers" else ["15"],
+        "defenders": ["0"] if local_player_side == "defenders" else ["15"],
+        "attacker_victory": attacker_victory,
+        "attacker_losses": "2",
+        "defender_losses": "9",
+        "system": "2",
+        "type": "ships",
+    }
+
+    stats = extractor._extract_battle_stats(
+        [battle],
+        player_id=0,
+        player_is_war_attacker=player_is_war_attacker,
+    )
+
+    assert stats["total_battles"] == 1
+    assert stats["our_victories"] == expected_our_victories
+    assert stats["their_victories"] == expected_their_victories
+    assert stats["unknown_outcomes"] == 0
+    assert stats["our_ship_losses"] == expected_our_losses
+    assert stats["their_ship_losses"] == expected_their_losses
 
 
 def test_extract_battle_stats_accepts_dict_participants():
@@ -86,12 +113,102 @@ def test_extract_battle_stats_accepts_dict_participants():
         },
     ]
 
-    stats = extractor._extract_battle_stats(battles, player_id=0)
+    stats = extractor._extract_battle_stats(
+        battles,
+        player_id=0,
+        player_is_war_attacker=True,
+    )
 
     assert stats["total_battles"] == 1
     assert stats["our_victories"] == 1
     assert stats["our_ship_losses"] == 2
     assert stats["their_ship_losses"] == 9
+
+
+def test_summarize_war_control_includes_capital_and_system_evidence():
+    summary = DummyMilitaryExtractor._summarize_war_control(
+        lost_control_records=[
+            {
+                "owner_id": "15",
+                "controller_id": "0",
+                "fleet_id": "100",
+                "system_id": "9",
+                "system_name": "Enemy Prime",
+            },
+            {
+                "owner_id": "16",
+                "controller_id": "1",
+                "fleet_id": "101",
+                "system_id": "10",
+                "system_name": "Allied Advance",
+            },
+            {
+                "owner_id": "0",
+                "controller_id": "15",
+                "fleet_id": "102",
+                "system_id": "12",
+                "system_name": "Sol",
+            },
+        ],
+        capital_control={
+            "0": {"controller_id": "0", "system_id": "12", "capital_name": "Earth"},
+            "15": {"controller_id": "0", "system_id": "9", "capital_name": "Enemy Prime"},
+            "16": {"controller_id": "16", "system_id": "10", "capital_name": "Second Prime"},
+        },
+        our_side_ids={"0", "1"},
+        opposing_side_ids={"15", "16"},
+        player_id="0",
+        country_names={0: "Player", 1: "Ally", 15: "Enemy", 16: "Second Enemy"},
+    )
+
+    assert summary["enemy_starbase_assets_controlled_by_our_side"] == 2
+    assert summary["enemy_assets_controlled_by_player"] == 1
+    assert {entry["system_id"] for entry in summary["enemy_systems_controlled_by_our_side"]} == {
+        "9",
+        "10",
+    }
+    assert [
+        entry["empire"] for entry in summary["enemy_capital_colonies_occupied_by_our_side"]
+    ] == ["Enemy"]
+    assert {
+        entry["empire"] for entry in summary["enemy_capital_systems_controlled_by_our_side"]
+    } == {"Enemy", "Second Enemy"}
+    assert summary["our_starbase_assets_controlled_by_enemy_side"] == 1
+    assert summary["player_capital_colony_occupied_by_enemy_side"] is False
+    assert summary["player_capital_system_controlled_by_enemy_side"] is True
+
+
+def test_battle_diagnostic_record_exposes_raw_and_parent_side_calculation():
+    extractor = DummyMilitaryExtractor()
+    battle = {
+        "attackers": ["15"],
+        "defenders": ["0"],
+        "attacker_victory": "yes",
+        "attacker_losses": "1",
+        "defender_losses": "15",
+        "system": "2",
+        "type": "ships",
+    }
+
+    diagnostic = extractor._build_battle_diagnostic_record(
+        battle,
+        local_attackers={"15"},
+        local_defenders={"0"},
+        player_is_war_attacker=True,
+    )
+
+    assert diagnostic == {
+        "local_attacker_country_ids": ["15"],
+        "local_defender_country_ids": ["0"],
+        "raw_attacker_victory": "yes",
+        "raw_attacker_losses": 1,
+        "raw_defender_losses": 15,
+        "battle_type": "ships",
+        "system_id": "2",
+        "computed_result": "our_side_victory",
+        "computed_our_side_losses": 1,
+        "computed_opposing_side_losses": 15,
+    }
 
 
 def test_classify_megastructure_status_uses_live_state_not_stage_suffix():
@@ -199,7 +316,13 @@ def test_real_save_battle_stats_match_raw_player_participation(test_save_path):
         if player_id not in attackers and player_id not in defenders:
             continue
 
-        expected = {"total_battles": 0, "our_victories": 0, "their_victories": 0}
+        player_is_war_attacker = player_id in attackers
+        expected = {
+            "total_battles": 0,
+            "our_victories": 0,
+            "their_victories": 0,
+            "unknown_outcomes": 0,
+        }
         battles = war.get("battles", [])
         if isinstance(battles, list):
             for battle in battles:
@@ -215,10 +338,10 @@ def test_real_save_battle_stats_match_raw_player_participation(test_save_path):
                     continue
 
                 expected["total_battles"] += 1
-                attacker_victory = battle.get("attacker_victory") == "yes"
-                if (player_was_attacker and attacker_victory) or (
-                    player_was_defender and not attacker_victory
-                ):
+                attacker_victory = battle.get("attacker_victory")
+                if attacker_victory not in {"yes", "no"}:
+                    expected["unknown_outcomes"] += 1
+                elif (attacker_victory == "yes") == player_is_war_attacker:
                     expected["our_victories"] += 1
                 else:
                     expected["their_victories"] += 1
@@ -228,20 +351,33 @@ def test_real_save_battle_stats_match_raw_player_participation(test_save_path):
     with rust_session(test_save_path):
         extractor = SaveExtractor(test_save_path)
         wars = extractor.get_wars()
+        diagnostics = extractor.get_war_diagnostics()
 
     assert wars["player_at_war"] is True
     assert wars["active_war_count"] == len(expected_by_war)
+    assert diagnostics["schema_version"] == 2
+    assert diagnostics["result_orientation"] == "parent_war_side"
+    assert diagnostics["included_battles"] == 0
+    assert diagnostics["wars"][0]["direct_battle_count"] == 0
 
     actual_by_war = [
         {
             "total_battles": war["battle_stats"]["total_battles"],
             "our_victories": war["battle_stats"]["our_victories"],
             "their_victories": war["battle_stats"]["their_victories"],
+            "unknown_outcomes": war["battle_stats"]["unknown_outcomes"],
         }
         for war in wars["wars"]
     ]
     assert (
         actual_by_war
         == expected_by_war
-        == [{"total_battles": 0, "our_victories": 0, "their_victories": 0}]
+        == [
+            {
+                "total_battles": 0,
+                "our_victories": 0,
+                "their_victories": 0,
+                "unknown_outcomes": 0,
+            }
+        ]
     )

--- a/tests/test_model_briefing.py
+++ b/tests/test_model_briefing.py
@@ -40,4 +40,40 @@ def test_model_briefing_json_falls_back_for_invalid_json() -> None:
     assert build_model_briefing_json("not-json") == "not-json"
 
     parsed = json.loads(build_model_briefing_json('{"meta":{"version":"Corvus v4.2.4"}}'))
-    assert parsed["model_context"]["schema_version"] == 1
+    assert parsed["model_context"]["schema_version"] == 2
+
+
+def test_model_briefing_adds_explicit_war_side_semantics_and_aliases() -> None:
+    source = {
+        "meta": {"version": "Pegasus v4.4.6"},
+        "military": {
+            "wars": {
+                "wars": [
+                    {
+                        "our_side": "attacker",
+                        "battle_stats": {
+                            "total_battles": 35,
+                            "our_victories": 25,
+                            "their_victories": 10,
+                            "unknown_outcomes": 0,
+                            "our_ship_losses": 69,
+                            "their_ship_losses": 258,
+                        },
+                    }
+                ]
+            }
+        },
+    }
+
+    result = build_model_briefing(source)
+    stats = result["military"]["wars"]["wars"][0]["battle_stats"]
+
+    assert stats["player_involved_battles"] == 35
+    assert stats["our_side_victories"] == 25
+    assert stats["opposing_side_victories"] == 10
+    assert stats["our_side_ship_losses"] == 69
+    assert stats["opposing_side_ship_losses"] == 258
+    assert (
+        "not a complete measure" in result["model_context"]["military"]["wars"]["assessment_rule"]
+    )
+    assert "player_involved_battles" not in source["military"]["wars"]["wars"][0]["battle_stats"]

--- a/workers/stellaris-feedback/src/index.ts
+++ b/workers/stellaris-feedback/src/index.ts
@@ -41,6 +41,15 @@ interface ReportPayload {
       ingestionLastError?: string
       precomputeReady?: boolean
       t2Ready?: boolean
+      warDiagnostics?: {
+        schema_version?: number
+        player_id?: string
+        result_orientation?: string
+        loss_orientation?: string
+        wars?: unknown[]
+        included_battles?: number
+        truncated?: boolean
+      }
     }
     error?: {
       message: string
@@ -318,6 +327,17 @@ async function createGitHubIssue(
     if (typeof diag.precomputeReady === 'boolean') bodyParts.push(`**Precompute Ready:** ${diag.precomputeReady}`)
     if (typeof diag.t2Ready === 'boolean') bodyParts.push(`**Tier 2 Ready:** ${diag.t2Ready}`)
     if (diag.ingestionLastError) bodyParts.push(`**Ingestion Last Error:** ${diag.ingestionLastError}`)
+    if (diag.warDiagnostics) {
+      bodyParts.push(
+        '',
+        '<details><summary>War calculation diagnostics</summary>',
+        '',
+        '```json',
+        truncate(JSON.stringify(diag.warDiagnostics, null, 2), 24000),
+        '```',
+        '</details>'
+      )
+    }
   }
 
   if (context.error) {
@@ -450,6 +470,17 @@ async function addGitHubComment(
     if (typeof diag.precomputeReady === 'boolean') bodyParts.push(`**Precompute Ready:** ${diag.precomputeReady}`)
     if (typeof diag.t2Ready === 'boolean') bodyParts.push(`**Tier 2 Ready:** ${diag.t2Ready}`)
     if (diag.ingestionLastError) bodyParts.push(`**Ingestion Last Error:** ${diag.ingestionLastError}`)
+    if (diag.warDiagnostics) {
+      bodyParts.push(
+        '',
+        '<details><summary>War calculation diagnostics</summary>',
+        '',
+        '```json',
+        truncate(JSON.stringify(diag.warDiagnostics, null, 2), 24000),
+        '```',
+        '</details>'
+      )
+    }
   }
 
   bodyParts.push('', data.description)


### PR DESCRIPTION
## What changed

- Interpret battle outcomes and losses relative to the parent war coalitions, while using tactical participant lists only to identify direct player participation.
- Add occupation and capital-control evidence so the Advisor does not treat battle history as the whole state of a war.
- Add explicit model-facing war semantics and prevent stale Advisor answers from overriding current save evidence.
- Add bounded, opt-in war calculation diagnostics without uploading save files.
- Advance synchronized app/backend metadata and user-facing release notes to `1.0.0-beta.3`.

## Root cause

Stellaris stores `attacker_victory`, `attacker_losses`, and `defender_losses` relative to the parent war attacker/defender coalitions. The app incorrectly interpreted those fields relative to each battle's tactical `attackers` and `defenders` participant lists. When those lists appeared in the opposite tactical orientation, player victories and losses were inverted.

## User impact

Advisor war assessments now attribute victories, defeats, and casualties to the correct coalition and can consider occupied systems and capitals alongside battle history.

## Validation

- Python: 379 passed, 27 skipped.
- Rust parser: 37 passed.
- Electron: 48 passed.
- Renderer: TypeScript and production Vite build passed.
- Feedback worker: TypeScript passed; Vitest completed with no test files.
- Ruff lint/format and release version classification passed.

Refs #44