### PR TITLE
chore(release): prepare Stellaris Companion 1.0.0

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -5,4 +5,4 @@ Stellaris Companion Backend
 Electron app backend with a configurable strategic advisor for Stellaris.
 """
 
-__version__ = "1.0.0-beta.3"
+__version__ = "1.0.0"

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stellaris-companion",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stellaris-companion",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "electron-store": "^8.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellaris-companion",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0",
   "description": "Desktop companion app for Stellaris - AI-powered strategic advisor",
   "main": "main.js",
   "author": "Stellaris Companion",

--- a/electron/release-notes.md
+++ b/electron/release-notes.md
@@ -1,6 +1,6 @@
-**More trustworthy war assessments.**
+**The largest Stellaris Companion update yet.**
 
-- Corrected war victories, defeats, and casualties when tactical battle sides appear reversed in Stellaris saves.
-- Added occupation and capital-control evidence so the Advisor considers strategic progress as well as battle history.
-- Prevented stale Advisor responses from overriding evidence from the current save.
-- Added privacy-safe war diagnostics for future reports without uploading save files.
+- Choose the AI service that suits you, including Gemini, Ollama, LM Studio, OpenRouter, and other compatible providers.
+- Quickly find, rename, restore, or clean up previous campaigns.
+- Get more reliable Advisor guidance based on your current save and the latest Stellaris mechanics.
+- Enjoy improved performance, security, and reliability throughout the app.

--- a/electron/renderer/pages/ChroniclePage.tsx
+++ b/electron/renderer/pages/ChroniclePage.tsx
@@ -198,6 +198,7 @@ function ChroniclePage({
   const lastAutoSavesRefreshAtRef = useRef(0)
   const autoSavesRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastFocusChronicleRefreshAtRef = useRef(0)
+  const lastChronicleLoadStartedAtRef = useRef(0)
   const lastSeenIngestionUpdatedAtRef = useRef<number | null>(null)
   const didInitChapterSelectionRef = useRef(false)
   const pendingVisibleChronicleRefreshRef = useRef(false)
@@ -288,6 +289,7 @@ function ChroniclePage({
       return
     }
 
+    if (!chapterOnly) lastChronicleLoadStartedAtRef.current = Date.now()
     chronicleInFlightRef.current = true
     const token = ++chronicleRequestTokenRef.current
 
@@ -446,6 +448,8 @@ function ChroniclePage({
     if (!isDocumentVisible()) return
     if (!isMountedRef.current) return
 
+    const catchupStartedAt = Date.now()
+    if (catchupStartedAt - lastChronicleLoadStartedAtRef.current < 2000) return
     const requestTokenAtStart = chronicleRequestTokenRef.current
     visibleCatchupInFlightRef.current = true
 
@@ -455,6 +459,9 @@ function ChroniclePage({
       // Campaign selection invalidates a refresh that was queued for the
       // previously visible campaign while metadata was loading.
       if (requestTokenAtStart !== chronicleRequestTokenRef.current) return
+      // Initial activation may have loaded the Chronicle while this focus
+      // catch-up was refreshing metadata. Do not immediately load it again.
+      if (lastChronicleLoadStartedAtRef.current >= catchupStartedAt) return
       await loadChronicle(false, false)
     } finally {
       visibleCatchupInFlightRef.current = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stellaris-companion"
-version = "1.0.0-beta.3"
+version = "1.0.0"
 description = "AI-powered strategic advisor for Stellaris with configurable model providers"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release

Promotes the completed v1 beta line to the public Stable channel as Stellaris Companion 1.0.0.

## User-facing notes

**The largest Stellaris Companion update yet.**

- Choose the AI service that suits you, including Gemini, Ollama, LM Studio, OpenRouter, and other compatible providers.
- Quickly find, rename, restore, or clean up previous campaigns.
- Get more reliable Advisor guidance based on your current save and the latest Stellaris mechanics.
- Enjoy improved performance, security, and reliability throughout the app.

## Release mechanics

- Synchronizes the backend, Python package, Electron package, and lockfile at version 1.0.0.
- Classifies v1.0.0 as the Stable latest channel.
- Keeps Windows packaging unsigned, consistent with previous releases.

## Validation before push

- Version synchronization test passed.
- Stable release metadata and v1.0.0 tag classification passed.
- Electron unit tests: 49 passed.
- Renderer production build passed.
- PR #46 passed Python, Rust, Linux/Windows desktop, and Linux E2E checks.
- The release workflow will be run manually across all four platforms before this PR is merged.
